### PR TITLE
Zero as icons

### DIFF
--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -387,8 +387,8 @@ map_dep <- function(datapkg,
   # check zero_values_icon_size
   if (!is.null(zero_values_icon_size)) {
     assertthat::assert_that(
-      is.character(zero_values_icon_size),
-      msg = "Argument zero_values_icon_size must be a character (URL)."
+      is.numeric(zero_values_icon_size),
+      msg = "Argument zero_values_icon_size must be a number."
     )
     # check zero_values_icon_size in combination with zero_values_show
     if (zero_values_show == FALSE) {

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -57,8 +57,8 @@
 #' @param palette The palette name or the color function that values will be
 #'   mapped to.
 #'   Typically one of the following:
-#'   - A character vector of RGB or named colors. Examples: `palette(),
-#'   c("#000000", "#0000FF", "#FFFFFF")), palette(topo.colors(10))`.
+#'   - A character vector of RGB or named colors. Examples: `c("#000000",
+#'   "#0000FF", "#FFFFFF"))`,`topo.colors(10))`.
 #'   - the full name of a RColorBrewer palette, e.g. "BuPu" or "Greens", or
 #'   viridis palette: `"viridis"`, `"magma"`, `"inferno"` or `"plasma"`
 #'   For more options, see argument `palette` of [leaflet::colorNumeric()].
@@ -208,14 +208,14 @@
 #' map_dep(
 #'   mica,
 #'   "n_obs",
-#'   palette = palette(c("black", "blue", "white"))
+#'   palette = c("black", "blue", "white")
 #' )
 #'
 #' #' # use a palette defined by hex colors
 #' map_dep(
 #'   mica,
 #'   "n_obs",
-#'   palette = palette(c("#000000", "#0000FF", "#FFFFFF"))
+#'   palette = c("#000000", "#0000FF", "#FFFFFF")
 #' )
 #'
 #' #' # do not show deployments with zero values
@@ -347,7 +347,7 @@ map_dep <- function(datapkg,
     life_stage <- NULL
   }
 
-  # check palette
+  # check palette/colors
   viridis_valid_palettes <- c(
     "magma",
     "inferno",
@@ -356,15 +356,13 @@ map_dep <- function(datapkg,
   )
   r_color_brewer_palettes <- rownames(RColorBrewer::brewer.pal.info)
   palettes <- c(viridis_valid_palettes, r_color_brewer_palettes)
-  assertthat::assert_that(
-    length(palette) == 1,
-    msg = "Argument palette must be a valid color palette."
-  )
-  check_value(arg = palette,
+  if (length(palette) == 1) {
+    check_value(arg = palette,
                 options = palettes,
                 arg_name = "palette",
                 null_allowed = FALSE
-  )
+    )
+  }
 
   # check zero_values_icon_url
   if (!is.null(zero_values_icon_url)) {

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -89,7 +89,7 @@ list of columns you can use.}
 mapped to.
 Typically one of the following:
 \itemize{
-\item A character vector of RGB or named colors. Examples: \verb{palette(),   c("#000000", "#0000FF", "#FFFFFF")), palette(topo.colors(10))}.
+\item A character vector of RGB or named colors. Examples: \verb{c("#000000",   "#0000FF", "#FFFFFF"))},\verb{topo.colors(10))}.
 \item the full name of a RColorBrewer palette, e.g. "BuPu" or "Greens", or
 viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"} or \code{"plasma"}
 For more options, see argument \code{palette} of \code{\link[leaflet:colorNumeric]{leaflet::colorNumeric()}}.
@@ -246,14 +246,14 @@ map_dep(
 map_dep(
   mica,
   "n_obs",
-  palette = palette(c("black", "blue", "white"))
+  palette = c("black", "blue", "white")
 )
 
 #' # use a palette defined by hex colors
 map_dep(
   mica,
   "n_obs",
-  palette = palette(c("#000000", "#0000FF", "#FFFFFF"))
+  palette = c("#000000", "#0000FF", "#FFFFFF")
 )
 
 #' # do not show deployments with zero values

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -16,7 +16,9 @@ map_dep(
   hover_columns = c("n", "species", "deploymentID", "locationID", "locationName",
     "latitude", "longitude", "start", "end"),
   palette = "inferno",
-  zero_values_color = "red",
+  zero_values_show = TRUE,
+  zero_values_icon_url = "https://img.icons8.com/ios-glyphs/30/000000/multiply.png",
+  zero_values_icon_size = 10,
   relative_scale = TRUE,
   max_scale = NULL,
   radius_range = c(10, 50)
@@ -93,8 +95,15 @@ viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"} or \code{"pl
 For more options, see argument \code{palette} of \code{\link[leaflet:colorNumeric]{leaflet::colorNumeric()}}.
 }}
 
-\item{zero_values_color}{a string identifying a color, e.g. "black", "#03F".
-Default: "red".}
+\item{zero_values_show}{Logical indicating whether to show deployments with
+zero values. Default: \code{TRUE}.}
+
+\item{zero_values_icon_url}{character with URL to icon for showing
+deployments with zero values. Default: a cross (multiply symbol)
+\code{"https://img.icons8.com/ios-glyphs/30/000000/multiply.png"}.}
+
+\item{zero_values_icon_size}{a number to set the size of the icon to show
+deployments with wero values. Default: 10.}
 
 \item{relative_scale}{Logical indicating whether to use a relative color
 and radius scale (\code{TRUE}) or an absolute scale (\code{FALSE}). If absolute scale
@@ -247,22 +256,58 @@ map_dep(
   palette = palette(c("#000000", "#0000FF", "#FFFFFF"))
 )
 
-#' # use a specific color for zero values other than default ("red")
+#' # do not show deployments with zero values
 map_dep(
   mica,
   "n_obs",
   life_stage = "subadult",
-  zero_values_color = "green"
+  zero_values_show = FALSE
+)
+
+#' # use same icon but but a non default color for zero values deployments,
+e.g. red (hex: E74C3C)
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_icon_url = "https://img.icons8.com/ios-glyphs/30/E74C3C/multiply.png"
+)
+
+# or yellow (F1C40F)
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_icon_url = "https://img.icons8.com/ios-glyphs/30/F1C40F/multiply.png"
+)
+
+# use another icon via a different URL, e.g. the character Fry from Futurama
+in green (2ECC71)
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_icon_url = "https://img.icons8.com/ios-glyphs/30/2ECC71/futurama-fry.png"
+)
+
+# set size of the icon for zero values deployments
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_size = 30
 )
 
 # disable cluster
-map_dep(mica,
+map_dep(
+  mica,
   "n_species",
   cluster = FALSE
 )
 
 # show only number of observations and location name while hovering
-map_dep(mica,
+map_dep(
+  mica,
   "n_obs",
   hover_columns = c("locationName", "n")
 )

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -89,7 +89,7 @@ list of columns you can use.}
 mapped to.
 Typically one of the following:
 \itemize{
-\item A character vector of RGB or named colors. Examples: \verb{palette(),   c("#000000", "#0000FF", "#FFFFFF"), topo.colors(10)}.
+\item A character vector of RGB or named colors. Examples: \verb{palette(),   c("#000000", "#0000FF", "#FFFFFF")), palette(topo.colors(10))}.
 \item the full name of a RColorBrewer palette, e.g. "BuPu" or "Greens", or
 viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"} or \code{"plasma"}
 For more options, see argument \code{palette} of \code{\link[leaflet:colorNumeric]{leaflet::colorNumeric()}}.
@@ -295,7 +295,7 @@ map_dep(
   mica,
   "n_obs",
   life_stage = "subadult",
-  zero_values_size = 30
+  zero_values_icon_size = 30
 )
 
 # disable cluster

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -277,13 +277,13 @@ map_dep(
 )
 ```
 
-Another easy way to specify a palette is to create it by passing some colors as a vector to the function `palette()`, e.g. `c("black", "blue", "white")`:
+Another easy way to specify a palette is to create it by passing a vector of colors as names or hex colors, e.g. `c("black", "blue", "#A3675F")`:
 
 ```{r use_black_blue_white}
 map_dep(
   mica,
   "n_obs",
-  palette = palette(value = c("black", "blue", "white"))
+  palette = c("black", "blue", "#A3675F")
 )
 ```
 

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -287,32 +287,45 @@ map_dep(
 )
 ```
 
-### Use a specific color for zero values
+### Use a specific icon and color for zero values
 
-You can pass to `zero_value_colors` argument your own color, e.g. `"green"` (color name) or `"#03F"` (hex). Modifying the default  value (`"red"`) can be useful as the color of deployments with zero values can be sometimes too similar to one of the colors used in the palette.
+You can pass to `zero_value_icon_url` argument the URL to an icon and to  `zero_values_icon_size` the size in pixels of such icon. There are several icon libraries you can choose from. A library with many free icons is [icons8](https://icons8.com/). Here, an example with the icon of Fry from Futurama animation series, color style, and size 50: 
 
-Use a color name: 
+```{r fry_futurama}
+map_dep(
+  mica,
+  "n_obs",
+  life_stage = "subadult",
+  zero_values_icon_url = "https://img.icons8.com/color/48/000000/futurama-fry.png",
+  zero_values_icon_size = 50
+)
+```
+
+Tipically the color is part of the URL. Here below two examples where we change the color of the default icon to green (2ECC71):
 
 ```{r specify_zero_colors_value_example_1}
 map_dep(
   mica,
   "n_obs",
   life_stage = "subadult",
-  zero_values_color = "green"
+  zero_values_icon_url = 
+    "https://img.icons8.com/ios-glyphs/30/2ECC71/multiply.png"
 )
 ```
 
-Use a hexadecimal color:
+or the INBO fuchsia (#C04384):
 
 ```{r specify_zero_colors_value_example_2}
 map_dep(
   mica,
   "n_obs",
   life_stage = "subadult",
-  zero_values_color = "#00A58F"
+  zero_values_icon_url = 
+    "https://img.icons8.com/ios-glyphs/30/C04384/multiply.png"
 )
 ```
 
+Modifying the default value (`"black"`) can be useful as the color of deployments with zero values can be sometimes too similar to one of the colors used in the palette.
 
 ### Modify circle size
 


### PR DESCRIPTION
This PR solves #34 by using icons for deploys with zero values. 
Args added:
- `zero_values_show`: `TRUE` (default) or `FALSE`
- `zero_Values_icon_url`: an URL to an icon. Default, the multiply symbol `x` as in [`"https://img.icons8.com/ios-glyphs/30/000000/multiply.png"`](https://img.icons8.com/ios-glyphs/30/000000/multiply.png).
- `zero_values_icon_size`: number of pixels. Default: 10.

This PR fixes also a bug and improves documentation while passing a vector of colors to `palette` argument.