### PR TITLE
Remove `here`, update read_camtrap_dp example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ Imports:
     dplyr,
     frictionless,
     glue,
-    here,
     htmltools,
     leaflet,
     lifecycle,

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -27,13 +27,12 @@
 #'
 #' @examples
 #' \dontrun{
-#' library(here)
 #' # Read Camtrap DP package
-#' camtrap_dp_dir <- here("inst", "extdata", "mica", "datapackage.json")
-#' muskrat_coypu <- read_camtrap_dp(camtrap_dp_dir)
+#' camtrap_dp_file <-  system.file("extdata", "mica", "datapackage.json", package = "camtraptor")
+#' muskrat_coypu <- read_camtrap_dp(camtrap_dp_file)
 #'
 #' # Read Camtrap DP package and ignore media file
-#' muskrat_coypu <- read_camtrap_dp(camtrap_dp_dir, media = FALSE)
+#' muskrat_coypu <- read_camtrap_dp(camtrap_dp_file, media = FALSE)
 #' }
 read_camtrap_dp <- function(file = NULL,
                             media = TRUE,

--- a/man/read_camtrap_dp.Rd
+++ b/man/read_camtrap_dp.Rd
@@ -35,12 +35,11 @@ metadata (slot \code{taxonomic}), if present.
 }
 \examples{
 \dontrun{
-library(here)
 # Read Camtrap DP package
-camtrap_dp_dir <- here("inst", "extdata", "mica", "datapackage.json")
-muskrat_coypu <- read_camtrap_dp(camtrap_dp_dir)
+camtrap_dp_file <-  system.file("extdata", "mica", "datapackage.json", package = "camtraptor")
+muskrat_coypu <- read_camtrap_dp(camtrap_dp_file)
 
 # Read Camtrap DP package and ignore media file
-muskrat_coypu <- read_camtrap_dp(camtrap_dp_dir, media = FALSE)
+muskrat_coypu <- read_camtrap_dp(camtrap_dp_file, media = FALSE)
 }
 }


### PR DESCRIPTION
- Rename variable in example to camtrap_dp_file rather than _dir (which was the old behaviour)
- Use system.file() rather than here() to get file
- Drop here dependency

The advantage of not using `here` is that you won't have name clashes with the `here()` function loaded from lubridate.