### PR TITLE
Fix #107

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.12.1
+Version: 0.13.0
 Authors@R: c(
     person(given = "Damiano",
            family = "Oldoni",

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -39,6 +39,16 @@ get_cam_op <- function(datapkg,
   # check data package
   check_datapkg(datapkg)
 
+  # Check that station_col is one of the columns in deployments
+  assertthat::assert_that(
+    station_col %in% names(datapkg$deployments),
+    msg = glue("station column name (station_col) not valid: ",
+               "it must be one of the deployments column names.")
+  )
+
+  assertthat::assert_that(use_prefix %in% c(TRUE, FALSE),
+                          msg = "use_prefix must be TRUE or FALSE.")
+
   # extract and apply filtering on deployments
   deploys <- apply_filter_predicate(
     df = datapkg$deployments,

--- a/tests/testthat/test-get_cam_op.R
+++ b/tests/testthat/test-get_cam_op.R
@@ -1,6 +1,13 @@
 test_that("input camtrap dp is checked properly", {
+  # character instead of datapackage
   expect_error(get_cam_op("aaa"))
+  # numeric instead of datapackage
   expect_error(get_cam_op(1))
+  # station_col value is not a column of deployments
+  expect_error(get_cam_op(mica, station_col = "bla"))
+  # use_prefix must be TRUE or FALSE
+  expect_error(get_cam_op(mica, use_prefix = "bla"))
+  expect_error(get_cam_op(mica, use_prefix = NA))
 })
 
 test_that("output is a matrix", {

--- a/tests/testthat/test-get_n_obs.R
+++ b/tests/testthat/test-get_n_obs.R
@@ -165,10 +165,10 @@ test_that(paste(
   species <- "Anas platyrhynchos"
   n_obs_via_sequence_id <-
     mica$observations %>%
-    filter(deploymentID == deploy_id) %>%
-    filter(scientificName == species) %>%
-    pull(sequenceID ) %>%
-    n_distinct()
+    dplyr::filter(.data$deploymentID == deploy_id) %>%
+    dplyr::filter(.data$scientificName == species) %>%
+    dplyr::pull(.data$sequenceID) %>%
+    dplyr::n_distinct()
   # one sequenceID  linked to two observations (different age, sex and count)
   n_obs <- get_n_obs(mica,
     species = "Mallard",
@@ -195,8 +195,8 @@ test_that("multiple sex values allowed", {
   expect_equal(
     tot_n_obs_females_unknown,
     mica$observations %>%
-      filter(sex %in% sex_value) %>%
-      distinct(sequenceID ) %>%
+      dplyr::filter(.data$sex %in% sex_value) %>%
+      dplyr::distinct(.data$sequenceID) %>%
       nrow()
   )
   expect_equal(nrow(n_obs_females_unknown), nrow(mica$deployments))
@@ -206,8 +206,8 @@ test_that("life_stage filters data correctly", {
   life_stage_value <- "subadult"
   n_obs_subadult_via_distinct <-
     mica$observations %>%
-    filter(lifeStage %in% life_stage_value) %>%
-    distinct(sequenceID ) %>%
+    dplyr::filter(.data$lifeStage %in% life_stage_value) %>%
+    dplyr::distinct(.data$sequenceID) %>%
     nrow()
   n_obs_subadult <- get_n_obs(mica, species = NULL, life_stage = life_stage_value)
   tot_n_obs_subadult <- sum(n_obs_subadult$n)
@@ -219,9 +219,9 @@ test_that("multiple age values allowed", {
   life_stage_value <- c("subadult", "adult")
   n_obs_subadult_adult <- get_n_obs(mica, species = NULL, life_stage = life_stage_value)
   tot_n_obs_subadult_adult <- sum(n_obs_subadult_adult$n)
-  n_obs_subadult_adult_calculate <- 
+  n_obs_subadult_adult_calculate <-
     mica$observations %>%
-    filter(lifeStage %in% life_stage_value) %>%
+    dplyr::filter(.data$lifeStage %in% life_stage_value) %>%
     nrow()
   expect_equal(tot_n_obs_subadult_adult,n_obs_subadult_adult_calculate )
   expect_equal(nrow(n_obs_subadult_adult), nrow(mica$deployments))


### PR DESCRIPTION
This PR adds checks for `station_col` (see #107) and `use_prefix` arguments at the very beginning of `get_cam_op()` function. This allows the user to be immediately aware of wrong arguments before they can generate strange errors in the middle of calculations. In other words, we just apply again **defensive programming** strategy.

Few tests related to these changes are added as well.