### PR TITLE
Document rounded coordinates in EML / DwC

### DIFF
--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -28,6 +28,9 @@
 #' - **license**: License with scope `data` as provided in `package$licenses`.
 #' - **rights** for media files: License with scope `media` as provided in
 #'   `package$licenses`.
+#' - **dwc:dataGeneralizations**: "coordinates rounded to
+#'   `package$coordinatePrecision` degrees".
+#' - **coordinatePrecision**: `package$coordinatePrecision` (e.g. `0.001`).
 write_dwc <- function(package, directory = ".") {
   # Set properties from metadata
   dataset_name <- package$title
@@ -36,6 +39,7 @@ write_dwc <- function(package, directory = ".") {
   collection_code <- package$platform$title
   license <- purrr::keep(package$licenses, ~ .$scope == "data")[[1]]$path
   media_license <- purrr::keep(package$licenses, ~ .$scope == "media")[[1]]$path
+  coordinate_precision <- package$coordinatePrecision
 
   # Create database
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")

--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -36,7 +36,8 @@
 #' - **description**: Description as provided in `description` or
 #'   `package$description`.
 #'   The description is preceded by an automatically generated paragraph
-#'   describing from which project and platform the dataset is derived.
+#'   describing from which project and platform the dataset is derived, and
+#'   to which extend coordinates are rounded (`package$coordinatePrecision`).
 #' - **license**: License with scope `data` as provided in `package$licenses`.
 #' - **creators**: Contributors (all roles) as provided in
 #'   `package$contributors`, filtered/reordered based on `creators`.
@@ -101,6 +102,7 @@ write_eml <- function(package, directory = ".", title = package$title,
     "and only include observations (and associated media) of animals. ",
     "Excluded are records that document blank or unclassified media, ",
     "vehicles and observations of humans. ",
+    "Geospatial coordinates are {rounded_coordinates}. ",
     "The original dataset description follows.",
     project = if (is.null(project$path)) {
       glue::glue("<em>{project$title}</em>")
@@ -111,6 +113,11 @@ write_eml <- function(package, directory = ".", title = package$title,
       platform$title
     } else {
       glue::glue("<a href=\"{platform$path}\">{platform$title}</a>")
+    },
+    rounded_coordinates = if (is.null(package$coordinatePrecision)) {
+      "provided as is"
+    } else {
+      glue::glue("rounded to {package$coordinatePrecision} degrees")
     },
     .null = ""
   )

--- a/inst/sql/dwc_occurrence.sql
+++ b/inst/sql/dwc_occurrence.sql
@@ -60,6 +60,7 @@ SELECT
   {collection_code}                     AS collectionCode,
   {dataset_name}                        AS datasetName,
   'MachineObservation'                  AS basisOfRecord,
+  "coordinates rounded to " || {coordinate_precision} || " degrees" AS dataGeneralizations, -- Or NULL
 -- OCCURRENCE
   obs.observationID                     AS occurrenceID,
   obs.count                             AS individualCount,
@@ -97,6 +98,7 @@ SELECT
   dep.longitude                         AS decimalLongitude,
   'WGS84'                               AS geodeticDatum,
   dep.coordinateUncertainty             AS coordinateUncertaintyInMeters,
+  {coordinate_precision}                AS coordinatePrecision,
 -- IDENTIFICATION
   obs.classifiedBy                      AS identifiedBy,
   strftime('%Y-%m-%dT%H:%M:%SZ', datetime(obs.classificationTimestamp, 'unixepoch')) AS dateIdentified,

--- a/man/write_dwc.Rd
+++ b/man/write_dwc.Rd
@@ -39,6 +39,9 @@ Can be a DOI.
 \item \strong{license}: License with scope \code{data} as provided in \code{package$licenses}.
 \item \strong{rights} for media files: License with scope \code{media} as provided in
 \code{package$licenses}.
+\item \strong{dwc:dataGeneralizations}: "coordinates rounded to
+\code{package$coordinatePrecision} degrees".
+\item \strong{coordinatePrecision}: \code{package$coordinatePrecision} (e.g. \code{0.001}).
 }
 }
 

--- a/man/write_eml.Rd
+++ b/man/write_eml.Rd
@@ -59,7 +59,8 @@ The following properties are set:
 \item \strong{description}: Description as provided in \code{description} or
 \code{package$description}.
 The description is preceded by an automatically generated paragraph
-describing from which project and platform the dataset is derived.
+describing from which project and platform the dataset is derived, and
+to which extend coordinates are rounded (\code{package$coordinatePrecision}).
 \item \strong{license}: License with scope \code{data} as provided in \code{package$licenses}.
 \item \strong{creators}: Contributors (all roles) as provided in
 \code{package$contributors}, filtered/reordered based on \code{creators}.


### PR DESCRIPTION
EML now makes use of `package$coordinatePrecision` to state:

> Geospatial coordinates are provided as is.

or

> Geospatial coordinates are as rounded to {0.001} degrees

Darwin Core now make use of `package$coordinatePrecision` to add:

- dataGeneralizations: "coordinates rounded to {0.001} degrees" (or NULL)
- coordinatePrecision: 0.001 (or NULL)

Ping @tucotuco