### PR TITLE
Fix #157

### DIFF
--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -26,6 +26,8 @@
 #' - `day`
 #' - `month`
 #' - `year`
+#' 
+#' If  `NULL` (default), the effort is returned in hours. 
 #' @param sex Character defining the sex class to filter on, e.g. `"female"`.
 #'   If `NULL`, default, all observations of all sex classes are taken into
 #'   account. Optional argument for `n_obs` and `n_individuals`.
@@ -177,6 +179,12 @@
 #'   life_stage = "adult"
 #' )
 #'
+#' # show effort (hours)
+#' map_dep(
+#'   mica,
+#'   "effort"
+#' )
+#' 
 #' # show effort (days)
 #' map_dep(
 #'   mica,
@@ -184,13 +192,7 @@
 #'   effort_unit = "day"
 #' )
 #'
-#' # show effort (months)
-#' map_dep(
-#'   mica,
-#'   "effort",
-#'   effort_unit = "month"
-#' )
-#'
+#'#'
 #' # use viridis palette (viridis palettes)
 #' map_dep(
 #'   mica,
@@ -492,10 +494,10 @@ map_dep <- function(package = NULL,
                                    life_stage = life_stage, ...)
     feat_df <- feat_df %>% dplyr::rename(n = .data$rai)
   } else if (feature == "effort") {
-    feat_df <- get_effort(package, unit = effort_unit, ...)
     if (is.null(effort_unit)) {
-      feat_df$effort <- feat_df$effort_duration
+      effort_unit <- "hour" # default value of get_effort()
     }
+    feat_df <- get_effort(package, unit = effort_unit, ...)
     feat_df <- feat_df %>% dplyr::rename(n = .data$effort)
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -112,6 +112,9 @@ check_value <- function(arg, options = NULL, arg_name, null_allowed = TRUE) {
     string_to_print <- "Invalid value for {arg_name} argument: {wrong_values}.
         Valid inputs are: NULL, {options_to_print*}."
   } else {
+    if (is.null(wrong_values)) {
+      wrong_values <- "NULL"
+    }
     string_to_print <- "Invalid value for {arg_name} argument: {wrong_values}.
         Valid inputs are: {options_to_print*}."
   }

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -61,7 +61,9 @@ and \code{n_individuals}.}
 \item \code{day}
 \item \code{month}
 \item \code{year}
-}}
+}
+
+If  \code{NULL} (default), the effort is returned in hours.}
 
 \item{cluster}{Logical value indicating whether using the cluster option
 while visualizing maps. Default: TRUE.}
@@ -217,6 +219,12 @@ map_dep(
   life_stage = "adult"
 )
 
+# show effort (hours)
+map_dep(
+  mica,
+  "effort"
+)
+
 # show effort (days)
 map_dep(
   mica,
@@ -224,13 +232,7 @@ map_dep(
   effort_unit = "day"
 )
 
-# show effort (months)
-map_dep(
-  mica,
-  "effort",
-  effort_unit = "month"
-)
-
+#'
 # use viridis palette (viridis palettes)
 map_dep(
   mica,

--- a/tests/testthat/test-get_effort.R
+++ b/tests/testthat/test-get_effort.R
@@ -1,56 +1,57 @@
-test_that("get_effort returns error if species is specified", {
-  expect_error(get_effort(mica, species = "Mallard"))
-  expect_error(get_effort(mica, species = character(0)))
+testthat::test_that("get_effort returns error for invalid effort units", {
+  testthat::expect_error(
+    get_effort(mica, unit = "bad_unit"),
+    "Invalid value for unit argument: bad_unit.
+Valid inputs are: second, minute, hour, day, month and year.")
+  testthat::expect_error(
+    get_effort(mica, unit = NULL),
+    "Invalid value for unit argument: NULL.
+Valid inputs are: second, minute, hour, day, month and year.")
 })
 
-test_that("get_effort returns error for invalid effort units", {
-  expect_error(get_effort(mica, unit = "bad_unit"))
-  expect_error(get_effort(mica, unit = NULL))
-})
-
-test_that("get_effort returns error for invalid datapackage", {
-  expect_error(get_effort(mica$data$deployments))
+testthat::test_that("get_effort returns error for invalid datapackage", {
+  testthat::expect_error(get_effort(mica$data$deployments))
 })
 
 
-test_that("values in column unit are all the same", {
+testthat::test_that("values in column unit are all the same", {
   effort_df <- get_effort(mica)
   distinct_efffort_unit_values <- unique(effort_df$unit)
-  expect_equal(length(distinct_efffort_unit_values), 1)
+  testthat::expect_equal(length(distinct_efffort_unit_values), 1)
 })
 
-test_that("column effort_duration is of class 'Duration'", {
+testthat::test_that("column effort_duration is of class 'Duration'", {
   effort_df <- get_effort(mica)
-  expect_equal(class(effort_df$effort_duration)[1], "Duration")
-  expect_equal(attr(class(effort_df$effort_duration),
+  testthat::expect_equal(class(effort_df$effort_duration)[1], "Duration")
+  testthat::expect_equal(attr(class(effort_df$effort_duration),
                    which = "package"),
               "lubridate")
 })
 
-test_that("column unit is always equal to argument unit", {
+testthat::test_that("column unit is always equal to argument unit", {
   unit_to_test <- c("second", "minute", "hour", "day", "month", "year")
   for (chosen_unit in unit_to_test) {
     effort_df <- get_effort(mica, unit = chosen_unit)
     efffort_unit_value <- unique(effort_df$unit)
-    expect_equal(efffort_unit_value, chosen_unit)
+    testthat::expect_equal(efffort_unit_value, chosen_unit)
   }
 })
 
 
-test_that("get_effort returns the right dataframe", {
+testthat::test_that("get_effort returns the right dataframe", {
   effort_df <- get_effort(mica)
 
   # type list
-  expect_type(effort_df, "list")
+  testthat::expect_type(effort_df, "list")
 
   # class tibble data.frame
-  expect_equal(
+  testthat::expect_equal(
     class(effort_df),
     c("tbl_df", "tbl", "data.frame")
   )
 
   # columns deploymentID, effort, unit and effort_duration only
-  expect_equal(
+  testthat::expect_equal(
     names(effort_df),
     c(
       "deploymentID",
@@ -62,20 +63,20 @@ test_that("get_effort returns the right dataframe", {
 })
 
 
-test_that("get_effort returns the right number of rows", {
+testthat::test_that("get_effort returns the right number of rows", {
   effort_df <- get_effort(mica)
   all_deployments <- unique(mica$data$deployments$deploymentID)
   n_all_deployments <- length(all_deployments)
 
   # number of rows should be equal to number of deployments
-  expect_equal(
+  testthat::expect_equal(
     nrow(effort_df),
     n_all_deployments
   )
 })
 
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
+testthat::test_that("Argument datapkg is deprecated: warning returned", {
+  testthat::expect_warning(
     rlang::with_options(
       lifecycle_verbosity = "warning",
       get_effort(datapkg = mica)


### PR DESCRIPTION
This PR solves #157.

Actually two bugs in once.

1. `get_effort()` changed behavior few months ago. Value `NULL` is not anymore allowed. We decided to return effort in hours by default instead of effort duration as "duration" object (which is a lubridate class and it is equivalent to seconds) coupled to `effort_unit = NULL`. As `map_dep` is calling `get_effort()` internally, I needed to take this change into account.
2. bug in `check_value()` as it seems that `glue()` flips out if `NULL` is passed as value to glue. 

I sharpened the tests of `get_effort()` to check the specific error returned.

@Rafnuss: can you please check if I solved the bug in #157 and review the PR? Thanks.