### PR TITLE
Fix #131: eventRemarks + use fixed `camera trap` for samplingProtocol

### DIFF
--- a/inst/sql/dwc_audubon.sql
+++ b/inst/sql/dwc_audubon.sql
@@ -35,12 +35,12 @@ WITH observations_media AS (
 SELECT
   obs_med.observationID                 AS occurrenceID,
 -- provider: can be org managing the platform, but that info is not available
-  {media_license}                       AS rights,
+  {media_license}                       AS `dcterm:rights`,
   obs_med.mediaID                       AS identifier,
   CASE
     WHEN obs_med.fileMediatype LIKE '%video%' THEN 'MovingImage'
     ELSE 'StillImage'
-  END                                   AS type,
+  END                                   AS `dc:type`,
   obs_med._id                           AS providerManagedID,
   CASE
     WHEN obs_med.favourite AND obs_med.comments != '' THEN 'media marked as favourite | ' || obs_med.comments

--- a/inst/sql/dwc_occurrence.sql
+++ b/inst/sql/dwc_occurrence.sql
@@ -85,15 +85,25 @@ SELECT
   strftime('%Y-%m-%dT%H:%M:%SZ', datetime(dep.start, 'unixepoch')) ||
   '/' ||
   strftime('%Y-%m-%dT%H:%M:%SZ', datetime(dep.end, 'unixepoch')) AS samplingEffort, -- Duration of deployment
+  CASE
+    WHEN dep.baitUse IS 'none' THEN 'camera trap without bait'
+    WHEN dep.baitUse IS NOT NULL THEN 'camera trap with ' || dep.baitUse || ' bait'
+    ELSE 'camera trap'
+  END ||
+  CASE
+    WHEN dep.featureType IS 'none' THEN ''
+    WHEN dep.featureType IS 'other' THEN ' near other feature'
+    WHEN dep.featureType IS NOT NULL THEN ' near ' || dep.featureType
+    ELSE ''
+  END ||
   COALESCE(
-    dep.comments || ' | tags: ' || dep.tags,
-    'tags: ' || dep.tags,
-    dep.comments
+    ' | tags: ' || dep.tags || ' | ' || dep.comments,
+    ' | tags: ' || dep.tags,
+    ' | ' || dep.comments
   )                                     AS eventRemarks,
 -- LOCATION
   dep.locationID                        AS locationID,
   dep.locationName                      AS locality,
-  dep.featureType                       AS locationRemarks,
   dep.latitude                          AS decimalLatitude,
   dep.longitude                         AS decimalLongitude,
   'WGS84'                               AS geodeticDatum,

--- a/inst/sql/dwc_occurrence.sql
+++ b/inst/sql/dwc_occurrence.sql
@@ -76,12 +76,7 @@ SELECT
   obs.deploymentID                      AS parentEventID,
   strftime('%Y-%m-%dT%H:%M:%SZ', datetime(obs.timestamp, 'unixepoch')) AS eventDate,
   dep.habitat                           AS habitat,
-  'camera trap' ||
-  CASE
-    WHEN dep.baitUse IS 'none' THEN ' without bait'
-    WHEN dep.baitUse IS NOT NULL THEN ' with bait'
-    ELSE ''
-  END                                   AS samplingProtocol,
+  'camera trap'                         AS samplingProtocol,
   strftime('%Y-%m-%dT%H:%M:%SZ', datetime(dep.start, 'unixepoch')) ||
   '/' ||
   strftime('%Y-%m-%dT%H:%M:%SZ', datetime(dep.end, 'unixepoch')) AS samplingEffort, -- Duration of deployment


### PR DESCRIPTION
- Drop `locationRemarks` (was used for featureType, but that is better expressed in `eventRemarks`)
- Create `eventRemarks` as:

```
camera trap with food bait near carcass | tags: boven de stroom | van 29/07/2020 tot 08/08/2020 120 foto's
camera trap without bait near other feature
camera trap
```
- Set `samplingProtocol` to fixed value `camera trap` (rather than `camera trap`, `camera trap with bait`, `camera trap without bait`) for easier searching in GBIF. Cf. `gps` for Movebank datasets.

fyi @tucotuco