### PR TITLE
Add non standard fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 # RStudio files
 .Rproj.user/
 .Rproj.user
-*.Rproj
 
 # produced vignettes
 vignettes/*.html

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.19.3
+Version: 0.19.4
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -93,7 +93,22 @@ read_camtrap_dp <- function(file = NULL,
       "`readr::problems()`."
     ))
   }
-
+  
+  # patch for non-standard values speed, radius, angle
+  # see https://github.com/inbo/camtraptor/issues/185
+  if ("X22" %in% names(observations)) {
+    observations <- observations %>%
+      dplyr::rename(speed=X22)
+  }
+  if ("X23" %in% names(observations)) {
+    observations <- observations %>%
+      dplyr::rename(radius=X23)
+  }
+  if ("X24" %in% names(observations)) {
+    observations <- observations %>%
+      dplyr::rename(angle=X24)
+  }
+  
   # create first version datapackage with resources in data element
   data <- list(
     "deployments" = deployments,

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -96,23 +96,18 @@ read_camtrap_dp <- function(file = NULL,
   
   # patch for non-standard values speed, radius, angle
   # see https://github.com/inbo/camtraptor/issues/185
-  
   obs_col_names <- names(observations)
-  
-  if ("X22" %in% names(observations)) {
+  if (all(c("X22", "X23", "X24") %in% names(observations))) {
     observations <- observations %>%
-      dplyr::rename(speed=X22)
-    message("Non standard field after _id found: renamed to speed.")
-  }
-  if ("X23" %in% names(observations)) {
-    observations <- observations %>%
-      dplyr::rename(radius=X23)
-    message("Non standard field after _id found: renamed to radius.")
-  }
-  if ("X24" %in% names(observations)) {
-    observations <- observations %>%
-      dplyr::rename(angle=X24)
-    message("Non standard field after _id found: renamed to angle.")
+      dplyr::rename(speed=X22,
+                    radius=X23,
+                    angle=X24
+    )
+    message(
+      paste0("Three extra fields in observations interpreted as speed,",
+             " radius and angle."
+      )
+    )
   }
   
   # create first version datapackage with resources in data element

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -135,7 +135,7 @@ read_camtrap_dp <- function(file = NULL,
       )
     observations <-
       observations %>%
-      dplyr::relocate(dplyr::one_of(cols_taxon_infos), .after = .data$cameraSetup)
+      dplyr::relocate(dplyr::one_of(cols_taxon_infos), .after = cameraSetup)
     # Inherit parsing issues from reading
     attr(observations, which = "problems") <- issues_observations
     package$data$observations <- observations

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -96,17 +96,23 @@ read_camtrap_dp <- function(file = NULL,
   
   # patch for non-standard values speed, radius, angle
   # see https://github.com/inbo/camtraptor/issues/185
+  
+  obs_col_names <- names(observations)
+  
   if ("X22" %in% names(observations)) {
     observations <- observations %>%
       dplyr::rename(speed=X22)
+    message("Non standard field after _id found: renamed to speed.")
   }
   if ("X23" %in% names(observations)) {
     observations <- observations %>%
       dplyr::rename(radius=X23)
+    message("Non standard field after _id found: renamed to radius.")
   }
   if ("X24" %in% names(observations)) {
     observations <- observations %>%
       dplyr::rename(angle=X24)
+    message("Non standard field after _id found: renamed to angle.")
   }
   
   # create first version datapackage with resources in data element

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -99,13 +99,10 @@ read_camtrap_dp <- function(file = NULL,
   obs_col_names <- names(observations)
   if (all(c("X22", "X23", "X24") %in% names(observations))) {
     observations <- observations %>%
-      dplyr::rename(speed=X22,
-                    radius=X23,
-                    angle=X24
-    )
+      dplyr::rename(speed = X22, radius = X23, angle = X24)
     message(
-      paste0("Three extra fields in observations interpreted as speed,",
-             " radius and angle."
+      paste("Three extra fields in `observations` interpreted as `speed`,",
+            "`radius` and `angle`."
       )
     )
   }

--- a/camtraptor.Rproj
+++ b/camtraptor.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --as-cran

--- a/tests/testthat/test-read_camtrap_dp.R
+++ b/tests/testthat/test-read_camtrap_dp.R
@@ -1,27 +1,27 @@
-test_that("file is checked properly", {
-  expect_error(read_camtrap_dp("aaa"))
-  expect_error(read_camtrap_dp(1))
+testthat::test_that("file is checked properly", {
+  testthat::expect_error(read_camtrap_dp("aaa"))
+  testthat::expect_error(read_camtrap_dp(1))
 })
 
 testthat::test_that("test warnings", {
   local_edition(2)
   camtrap_dp_file_with_issues <- system.file("extdata", "mica_parsing_issues", "datapackage_for_parsing_issues.json", package = "camtraptor")
   # deployments
-  expect_warning(
+  testthat::expect_warning(
     camtraptor::read_camtrap_dp(
       file = camtrap_dp_file_with_issues
     ),
     "One or more parsing issues occurred while reading deployments."
   )
   # observations
-  expect_warning(
+  testthat::expect_warning(
     camtraptor::read_camtrap_dp(
       file = camtrap_dp_file_with_issues
     ),
     "One or more parsing issues occurred while reading observations."
   )
   # media
-  expect_warning(
+  testthat::expect_warning(
     camtraptor::read_camtrap_dp(
       file = camtrap_dp_file_with_issues
     ),
@@ -30,17 +30,17 @@ testthat::test_that("test warnings", {
 })
 
 
-test_that("media is checked properly", {
+testthat::test_that("media is checked properly", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
-  expect_error(read_camtrap_dp(
+  testthat::expect_error(read_camtrap_dp(
     file = dp_path,
     media = "must_be_a_logical!"
   ))
 })
 
-test_that("output is a list", {
+testthat::test_that("output is a list", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -48,11 +48,11 @@ test_that("output is a list", {
     file = dp_path,
     media = FALSE
   )
-  expect_true(is.list(dp_without_media))
-  expect_equal(class(dp_without_media), "list")
+  testthat::expect_true(is.list(dp_without_media))
+  testthat::expect_equal(class(dp_without_media), "list")
 })
 
-test_that("output data slot is a list of length 3", {
+testthat::test_that("output data slot is a list of length 3", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -60,11 +60,11 @@ test_that("output data slot is a list of length 3", {
     file = dp_path,
     media = FALSE
   )
-  expect_true("data" %in% names(dp_without_media))
-  expect_equal(length(dp_without_media$data), 3)
+  testthat::expect_true("data" %in% names(dp_without_media))
+  testthat::expect_equal(length(dp_without_media$data), 3)
 })
 
-test_that("media arg influences only slot media", {
+testthat::test_that("media arg influences only slot media", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -77,16 +77,16 @@ test_that("media arg influences only slot media", {
     media = FALSE
   )
   # media is NULL only for dp_without_media
-  expect_null(dp_without_media$data$media)
-  expect_false(is.null(dp_with_media$data$media))
+  testthat::expect_null(dp_without_media$data$media)
+  testthat::expect_false(is.null(dp_with_media$data$media))
   # metadata are the same
   metadata_with_media <- dp_with_media
   metadata_with_media$data <- NULL
   metadata_without_media <- dp_without_media
   metadata_without_media$data <- NULL
-  expect_identical(metadata_with_media, metadata_without_media)
+  testthat::expect_identical(metadata_with_media, metadata_without_media)
   # observations are the same
-  expect_identical(
+  testthat::expect_identical(
     # remove columns with NA only
     dp_with_media$data$observations[colSums(
       !is.na(dp_with_media$data$observations)
@@ -97,7 +97,7 @@ test_that("media arg influences only slot media", {
     ) > 0]
   )
   # deployments are the same
-  expect_identical(
+  testthat::expect_identical(
     # remove columns with NA only
     dp_with_media$data$deployments[colSums(
       !is.na(dp_with_media$data$deployments)
@@ -109,7 +109,7 @@ test_that("media arg influences only slot media", {
   )
 })
 
-test_that("Datapackage resources are named as in resource_names", {
+testthat::test_that("Datapackage resources are named as in resource_names", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -118,10 +118,10 @@ test_that("Datapackage resources are named as in resource_names", {
     media = FALSE
   )
   resource_names <- dp_without_media$resource_names
-  expect_true(all(resource_names %in% names(dp_without_media$data)))
+  testthat::expect_true(all(resource_names %in% names(dp_without_media$data)))
 })
 
-test_that("Datapackage resources are tibble dataframes", {
+testthat::test_that("Datapackage resources are tibble dataframes", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -129,13 +129,13 @@ test_that("Datapackage resources are tibble dataframes", {
     file = dp_path,
     media = FALSE
   )
-  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp_without_media$data$deployments)))
-  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp_without_media$data$observations)))
 })
 
-test_that("sc. names and vernacular names in obs match the info in taxonomic slot", {
+testthat::test_that("sc. names and vernacular names in obs match the info in taxonomic slot", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -148,54 +148,54 @@ test_that("sc. names and vernacular names in obs match the info in taxonomic slo
     function(x) x %>% as.data.frame()
   ) %>%
     dplyr::tibble()
-  expect_true(all(names(taxon_infos) %in% names(dp$data$observations)))
+  testthat::expect_true(all(names(taxon_infos) %in% names(dp$data$observations)))
   # get scientific names from observations and check that they match with
   # taxonomic info
   sc_names <- dp$data$observations$scientificName[!is.na(
     dp$data$observations$scientificName
   )]
-  expect_true(all(sc_names %in% taxon_infos$scientificName))
+  testthat::expect_true(all(sc_names %in% taxon_infos$scientificName))
 
   # get vernacular names in English from observations and check that they match
   # with taxonomic info
   en_names <- dp$data$observations$vernacularNames.en[!is.na(
     dp$data$observations$vernacularNames.en
   )]
-  expect_true(all(en_names %in% taxon_infos$vernacularNames.en))
+  testthat::expect_true(all(en_names %in% taxon_infos$vernacularNames.en))
 
   # get vernacular names in Dutch from observations and check that they match
   # with taxonomic info
   nl_names <- dp$data$observations$vernacularNames.nl[!is.na(
     dp$data$observations$vernacularNames.nl
   )]
-  expect_true(all(nl_names %in% taxon_infos$vernacularNames.nl))
+  testthat::expect_true(all(nl_names %in% taxon_infos$vernacularNames.nl))
 })
 
-test_that("file can be an URL", {
+testthat::test_that("file can be an URL", {
   dp_path <- "https://raw.githubusercontent.com/tdwg/camtrap-dp/main/example/datapackage.json"
   dp <- read_camtrap_dp(
     file = dp_path,
     media = FALSE
   )
-  expect_true(is.list(dp))
-  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  testthat::expect_true(is.list(dp))
+  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp$data$deployments)))
-  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp$data$observations)))
 })
 
-test_that("path is deprecated", {
+testthat::test_that("path is deprecated", {
   dp_path_warning <- system.file("extdata", "mica", package = "camtraptor")
   rlang::with_options(
     lifecycle_verbosity = "warning",
-    expect_warning(read_camtrap_dp(
+    testthat::expect_warning(read_camtrap_dp(
       file = dp_path_warning,
       media = FALSE
     ))
   )
   rlang::with_options(
     lifecycle_verbosity = "warning",
-    expect_warning(read_camtrap_dp(
+    testthat::expect_warning(read_camtrap_dp(
       path = dp_path_warning,
       media = FALSE
     ))

--- a/tests/testthat/test-read_camtrap_dp.R
+++ b/tests/testthat/test-read_camtrap_dp.R
@@ -1,27 +1,27 @@
-testthat::test_that("file is checked properly", {
-  testthat::expect_error(read_camtrap_dp("aaa"))
-  testthat::expect_error(read_camtrap_dp(1))
+test_that("file is checked properly", {
+  expect_error(read_camtrap_dp("aaa"))
+  expect_error(read_camtrap_dp(1))
 })
 
-testthat::test_that("test warnings", {
+test_that("test warnings", {
   local_edition(2)
   camtrap_dp_file_with_issues <- system.file("extdata", "mica_parsing_issues", "datapackage_for_parsing_issues.json", package = "camtraptor")
   # deployments
-  testthat::expect_warning(
+  expect_warning(
     camtraptor::read_camtrap_dp(
       file = camtrap_dp_file_with_issues
     ),
     "One or more parsing issues occurred while reading deployments."
   )
   # observations
-  testthat::expect_warning(
+  expect_warning(
     camtraptor::read_camtrap_dp(
       file = camtrap_dp_file_with_issues
     ),
     "One or more parsing issues occurred while reading observations."
   )
   # media
-  testthat::expect_warning(
+  expect_warning(
     camtraptor::read_camtrap_dp(
       file = camtrap_dp_file_with_issues
     ),
@@ -30,17 +30,17 @@ testthat::test_that("test warnings", {
 })
 
 
-testthat::test_that("media is checked properly", {
+test_that("media is checked properly", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
-  testthat::expect_error(read_camtrap_dp(
+  expect_error(read_camtrap_dp(
     file = dp_path,
     media = "must_be_a_logical!"
   ))
 })
 
-testthat::test_that("output is a list", {
+test_that("output is a list", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -48,11 +48,11 @@ testthat::test_that("output is a list", {
     file = dp_path,
     media = FALSE
   )
-  testthat::expect_true(is.list(dp_without_media))
-  testthat::expect_equal(class(dp_without_media), "list")
+  expect_true(is.list(dp_without_media))
+  expect_equal(class(dp_without_media), "list")
 })
 
-testthat::test_that("output data slot is a list of length 3", {
+test_that("output data slot is a list of length 3", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -60,11 +60,11 @@ testthat::test_that("output data slot is a list of length 3", {
     file = dp_path,
     media = FALSE
   )
-  testthat::expect_true("data" %in% names(dp_without_media))
-  testthat::expect_equal(length(dp_without_media$data), 3)
+  expect_true("data" %in% names(dp_without_media))
+  expect_equal(length(dp_without_media$data), 3)
 })
 
-testthat::test_that("media arg influences only slot media", {
+test_that("media arg influences only slot media", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -77,16 +77,16 @@ testthat::test_that("media arg influences only slot media", {
     media = FALSE
   )
   # media is NULL only for dp_without_media
-  testthat::expect_null(dp_without_media$data$media)
-  testthat::expect_false(is.null(dp_with_media$data$media))
+  expect_null(dp_without_media$data$media)
+  expect_false(is.null(dp_with_media$data$media))
   # metadata are the same
   metadata_with_media <- dp_with_media
   metadata_with_media$data <- NULL
   metadata_without_media <- dp_without_media
   metadata_without_media$data <- NULL
-  testthat::expect_identical(metadata_with_media, metadata_without_media)
+  expect_identical(metadata_with_media, metadata_without_media)
   # observations are the same
-  testthat::expect_identical(
+  expect_identical(
     # remove columns with NA only
     dp_with_media$data$observations[colSums(
       !is.na(dp_with_media$data$observations)
@@ -97,7 +97,7 @@ testthat::test_that("media arg influences only slot media", {
     ) > 0]
   )
   # deployments are the same
-  testthat::expect_identical(
+  expect_identical(
     # remove columns with NA only
     dp_with_media$data$deployments[colSums(
       !is.na(dp_with_media$data$deployments)
@@ -109,7 +109,7 @@ testthat::test_that("media arg influences only slot media", {
   )
 })
 
-testthat::test_that("Datapackage resources are named as in resource_names", {
+test_that("Datapackage resources are named as in resource_names", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -118,10 +118,10 @@ testthat::test_that("Datapackage resources are named as in resource_names", {
     media = FALSE
   )
   resource_names <- dp_without_media$resource_names
-  testthat::expect_true(all(resource_names %in% names(dp_without_media$data)))
+  expect_true(all(resource_names %in% names(dp_without_media$data)))
 })
 
-testthat::test_that("Datapackage resources are tibble dataframes", {
+test_that("Datapackage resources are tibble dataframes", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -129,13 +129,13 @@ testthat::test_that("Datapackage resources are tibble dataframes", {
     file = dp_path,
     media = FALSE
   )
-  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp_without_media$data$deployments)))
-  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp_without_media$data$observations)))
 })
 
-testthat::test_that("sc. names and vernacular names in obs match the info in taxonomic slot", {
+test_that("sc. names and vernacular names in obs match the info in taxonomic slot", {
   dp_path <- system.file("extdata", "mica", "datapackage.json",
     package = "camtraptor"
   )
@@ -148,54 +148,54 @@ testthat::test_that("sc. names and vernacular names in obs match the info in tax
     function(x) x %>% as.data.frame()
   ) %>%
     dplyr::tibble()
-  testthat::expect_true(all(names(taxon_infos) %in% names(dp$data$observations)))
+  expect_true(all(names(taxon_infos) %in% names(dp$data$observations)))
   # get scientific names from observations and check that they match with
   # taxonomic info
   sc_names <- dp$data$observations$scientificName[!is.na(
     dp$data$observations$scientificName
   )]
-  testthat::expect_true(all(sc_names %in% taxon_infos$scientificName))
+  expect_true(all(sc_names %in% taxon_infos$scientificName))
 
   # get vernacular names in English from observations and check that they match
   # with taxonomic info
   en_names <- dp$data$observations$vernacularNames.en[!is.na(
     dp$data$observations$vernacularNames.en
   )]
-  testthat::expect_true(all(en_names %in% taxon_infos$vernacularNames.en))
+  expect_true(all(en_names %in% taxon_infos$vernacularNames.en))
 
   # get vernacular names in Dutch from observations and check that they match
   # with taxonomic info
   nl_names <- dp$data$observations$vernacularNames.nl[!is.na(
     dp$data$observations$vernacularNames.nl
   )]
-  testthat::expect_true(all(nl_names %in% taxon_infos$vernacularNames.nl))
+  expect_true(all(nl_names %in% taxon_infos$vernacularNames.nl))
 })
 
-testthat::test_that("file can be an URL", {
+test_that("file can be an URL", {
   dp_path <- "https://raw.githubusercontent.com/tdwg/camtrap-dp/main/example/datapackage.json"
   dp <- read_camtrap_dp(
     file = dp_path,
     media = FALSE
   )
-  testthat::expect_true(is.list(dp))
-  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  expect_true(is.list(dp))
+  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp$data$deployments)))
-  testthat::expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
+  expect_true(all(c("tbl_df", "tbl", "data.frame") %in%
     class(dp$data$observations)))
 })
 
-testthat::test_that("path is deprecated", {
+test_that("path is deprecated", {
   dp_path_warning <- system.file("extdata", "mica", package = "camtraptor")
   rlang::with_options(
     lifecycle_verbosity = "warning",
-    testthat::expect_warning(read_camtrap_dp(
+    expect_warning(read_camtrap_dp(
       file = dp_path_warning,
       media = FALSE
     ))
   )
   rlang::with_options(
     lifecycle_verbosity = "warning",
-    testthat::expect_warning(read_camtrap_dp(
+    expect_warning(read_camtrap_dp(
       path = dp_path_warning,
       media = FALSE
     ))


### PR DESCRIPTION
This PR solves #185 and #182.
I have been quite conservative in solving #185 to avoid errors in case of renaming non-existing columns.
I do not trigger any warning but I inform the user about non standard fields by returning three messages on console:

```r
Non standard field after _id found: renamed to speed.                                                                 
Non standard field after _id found: renamed to radius.
Non standard field after _id found: renamed to angle.
```