### PR TITLE
Upgrade package based on dplyr 1.1.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,5 +60,5 @@ Encoding: UTF-8
 LazyData: true
 LazyDataCompression: bzip2
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Depends:
 Imports:
     assertthat,
     DBI,
-    dplyr,
+    dplyr (>= 1.1.0),
     EML,
     frictionless,
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,8 @@ Authors@R: c(
            role = "ctb", comment = c(ORCID = "0000-0001-6788-5876")),
     person("Lynn", "Pallemaerts", email = "lynn.pallemaerts@inbo.be",
            role = "ctb", comment = c(ORCID = "0000-0002-5034-5416")),
+    person("Pieter", "Huybrechts", email = "pieter.huybrechts@inbo.be",
+           role = "ctb", comment = c(ORCID = "0000-0002-6658-6062")),
     person("Research Institute for Nature and Forest (INBO)",
            role = "cph", comment = "https://www.vlaanderen.be/inbo/en-gb/"),
     person("LifeWatch Belgium",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.19.4
+Version: 0.19.5
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/R/check_species.R
+++ b/R/check_species.R
@@ -46,7 +46,7 @@ check_species <- function(package = NULL,
 
   all_species <-
     get_species(package) %>%
-    dplyr::select(-c(.data$taxonID, .data$taxonIDReference))
+    dplyr::select(-c("taxonID", "taxonIDReference"))
   check_value(
     tolower(species),
     unlist(all_species) %>% tolower(),

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -149,7 +149,7 @@ get_cam_op <- function(package = NULL,
       # that in the actual stadium of camera trap dp exchange format, 0s as
       # returned by camtrapR::cameraOperation()` meaning "camera(s) not
       # operational", will never occur.
-      dep_op[dep_op == 0] <- NA_real_
+      dep_op[dep_op == 0] <- NA
       dep_op[[names(dep_op)]] <- as.numeric(dep_op[[names(dep_op)]])
       return(dep_op)
     }

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -149,7 +149,7 @@ get_cam_op <- function(package = NULL,
       # that in the actual stadium of camera trap dp exchange format, 0s as
       # returned by camtrapR::cameraOperation()` meaning "camera(s) not
       # operational", will never occur.
-      dep_op <- dplyr::na_if(dep_op, y = 0)
+      dep_op[dep_op == 0] <- NA_real_
       dep_op[[names(dep_op)]] <- as.numeric(dep_op[[names(dep_op)]])
       return(dep_op)
     }

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -268,8 +268,8 @@ get_custom_effort <- function(package = NULL,
   sum_effort %>%
     dplyr::mutate(unit = unit) %>%
     dplyr::select(
-      .data$begin,
-      .data$effort,
-      .data$unit
+      "begin",
+      "effort",
+      "unit"
     )
 }

--- a/R/get_effort.R
+++ b/R/get_effort.R
@@ -57,7 +57,7 @@ get_effort <- function(package = NULL,
   effort_df <-
     deployments %>%
     dplyr::mutate(effort_duration = lubridate::as.duration(.data$end - .data$start)) %>%
-    dplyr::select(.data$deploymentID, .data$effort_duration)
+    dplyr::select("deploymentID", "effort_duration")
   # convert effort duration in specified effort time units (arg units)
   effort_df$effort <- transform_effort_to_common_units(
     effort = effort_df$effort_duration,
@@ -66,10 +66,10 @@ get_effort <- function(package = NULL,
   effort_df$unit <-unit
   effort_df %>%
     dplyr::relocate(
-      .data$deploymentID,
-      .data$effort,
-      .data$unit,
-      .data$effort_duration
+      deploymentID,
+      effort,
+      unit,
+      effort_duration
     )
 }
 

--- a/R/get_effort.R
+++ b/R/get_effort.R
@@ -66,10 +66,10 @@ get_effort <- function(package = NULL,
   effort_df$unit <-unit
   effort_df %>%
     dplyr::relocate(
-      deploymentID,
-      effort,
-      unit,
-      effort_duration
+      "deploymentID",
+      "effort",
+      "unit",
+      "effort_duration"
     )
 }
 

--- a/R/get_n_individuals.R
+++ b/R/get_n_individuals.R
@@ -147,8 +147,8 @@ get_n_individuals <- function(package = NULL,
       unique(c(observations$scientificName, species))
     ) %>%
     dplyr::rename(
-      deploymentID = .data$Var1,
-      scientificName = .data$Var2
+      deploymentID = "Var1",
+      scientificName = "Var2"
     ) %>%
     dplyr::as_tibble()
 
@@ -172,6 +172,6 @@ get_n_individuals <- function(package = NULL,
 
   # order result by deployments and following same order as in deployments df
   deployments %>%
-    dplyr::select(deploymentID) %>%
-    dplyr::left_join(n_individuals, by = "deploymentID")
+    dplyr::select("deploymentID") %>%
+    dplyr::left_join(n_individuals, by = "deploymentID", multiple = "all")
 }

--- a/R/get_n_obs.R
+++ b/R/get_n_obs.R
@@ -130,7 +130,7 @@ get_n_obs <- function(package = NULL,
   # get number of observations collected by each deployment for each species
   n_obs <-
     observations %>%
-    dplyr::group_by(deploymentID, scientificName) %>%
+    dplyr::group_by(.data$deploymentID, .data$scientificName) %>%
     dplyr::summarise(n = dplyr::n_distinct(.data$sequenceID)) %>%
     dplyr::ungroup()
 

--- a/R/get_n_obs.R
+++ b/R/get_n_obs.R
@@ -130,7 +130,7 @@ get_n_obs <- function(package = NULL,
   # get number of observations collected by each deployment for each species
   n_obs <-
     observations %>%
-    dplyr::group_by(.data$deploymentID, .data$scientificName) %>%
+    dplyr::group_by(deploymentID, scientificName) %>%
     dplyr::summarise(n = dplyr::n_distinct(.data$sequenceID)) %>%
     dplyr::ungroup()
 
@@ -140,7 +140,7 @@ get_n_obs <- function(package = NULL,
       deployments$deploymentID,
       unique(c(unique(observations$scientificName), species))
     ) %>%
-    dplyr::rename(deploymentID = .data$Var1, scientificName = .data$Var2) %>%
+    dplyr::rename(deploymentID = "Var1", scientificName = "Var2") %>%
     dplyr::as_tibble()
 
   # set 0 to combinations without observations (i.e. n = NA after join)
@@ -163,6 +163,6 @@ get_n_obs <- function(package = NULL,
 
   # order result by deployments and follow same order as in deployments df
   deployments %>%
-    dplyr::select(deploymentID) %>%
-    dplyr::left_join(n_obs, by = "deploymentID")
+    dplyr::select("deploymentID") %>%
+    dplyr::left_join(n_obs, by = "deploymentID", multiple = "all")
 }

--- a/R/get_n_species.R
+++ b/R/get_n_species.R
@@ -71,7 +71,7 @@ get_n_species <- function(package = NULL,
   # set up n = NA (number of species) for deployments without observations
   deployments_no_obs <-
     deployments_no_obs %>%
-    dplyr::select(.data$deploymentID) %>%
+    dplyr::select("deploymentID") %>%
     dplyr::mutate(n = NA_integer_)
 
   # add them to n_species and return

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -253,7 +253,7 @@ get_record_table <- function(package = NULL,
     dplyr::mutate(delta.time.days = .data$delta.time.hours / 24) %>%
     dplyr::mutate(dplyr::across(
       dplyr::starts_with("delta.time."),
-      \(x) tidyr::replace_na(x, 0)
+      .fns = function(x) tidyr::replace_na(x, 0)
     )) %>%
     dplyr::ungroup()
 

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -224,7 +224,7 @@ get_record_table <- function(package = NULL,
         deltaTimeComparedTo
       ))
     record_independence <- record_independence %>%
-      tidyr::unnest(cols = c(data))
+      tidyr::unnest(cols = c("data"))
     # add independence information to record_table
     record_table <- record_table %>%
       dplyr::left_join(record_independence,

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -207,7 +207,7 @@ get_record_table <- function(package = NULL,
       Date = lubridate::date(.data$timestamp),
       Time = format(.data$timestamp, format = "%H:%M:%S")
     ) %>%
-    dplyr::group_by(scientificName, !!rlang::sym(stationCol)) %>%
+    dplyr::group_by(.data$scientificName, !!rlang::sym(stationCol)) %>%
     dplyr::arrange(.data$scientificName, !!rlang::sym(stationCol), .data$timestamp)
   if (minDeltaTime == 0) {
     # observations are by default independent

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -108,7 +108,7 @@ get_record_table <- function(package = NULL,
   assertthat::assert_that(
     stationCol %in% names(package$data$deployments),
     msg = glue::glue(
-      "Station column name `stationCol` not valid: ",
+      "Station column name `{stationCol}` not valid: ",
       "It must be one of the deployments column names."
     )
   )

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -173,7 +173,8 @@ get_record_table <- function(package = NULL,
 
   # add station column from deployments to observations
   obs <- obs %>%
-    dplyr::left_join(deployments %>% dplyr::select(.data$deploymentID, !!rlang::sym(stationCol)),
+    dplyr::left_join(deployments %>% 
+                       dplyr::select("deploymentID", !!rlang::sym(stationCol)),
       by = "deploymentID"
     )
   # extract needed info from media and set file names and file paths as
@@ -181,10 +182,10 @@ get_record_table <- function(package = NULL,
   grouped_media_info <-
     package$data$media %>%
     dplyr::select(
-      .data$sequenceID,
-      .data$filePath,
-      .data$fileName,
-      .data$timestamp
+      "sequenceID",
+      "filePath",
+      "fileName",
+      "timestamp"
     ) %>%
     dplyr::group_by(.data$sequenceID) %>%
     dplyr::summarise(
@@ -206,7 +207,7 @@ get_record_table <- function(package = NULL,
       Date = lubridate::date(.data$timestamp),
       Time = format(.data$timestamp, format = "%H:%M:%S")
     ) %>%
-    dplyr::group_by(.data$scientificName, !!rlang::sym(stationCol)) %>%
+    dplyr::group_by(scientificName, !!rlang::sym(stationCol)) %>%
     dplyr::arrange(.data$scientificName, !!rlang::sym(stationCol), .data$timestamp)
   if (minDeltaTime == 0) {
     # observations are by default independent
@@ -252,29 +253,29 @@ get_record_table <- function(package = NULL,
     dplyr::mutate(delta.time.days = .data$delta.time.hours / 24) %>%
     dplyr::mutate(dplyr::across(
       dplyr::starts_with("delta.time."),
-      tidyr::replace_na, 0
+      \(x) tidyr::replace_na(x, 0)
     )) %>%
     dplyr::ungroup()
 
   record_table <- record_table %>%
     dplyr::rename(Station := !!stationCol,
-      Species = .data$scientificName,
-      DateTimeOriginal = .data$timestamp,
-      Directory = .data$filePath,
-      FileName = .data$fileName
+      Species = "scientificName",
+      DateTimeOriginal = "timestamp",
+      Directory = "filePath",
+      FileName = "fileName"
     ) %>%
     dplyr::select(
-      .data$Station,
-      .data$Species,
-      .data$DateTimeOriginal,
-      .data$Date,
-      .data$Time,
-      .data$delta.time.secs,
-      .data$delta.time.mins,
-      .data$delta.time.hours,
-      .data$delta.time.days,
-      .data$Directory,
-      .data$FileName
+      "Station",
+      "Species",
+      "DateTimeOriginal",
+      "Date",
+      "Time",
+      "delta.time.secs",
+      "delta.time.mins",
+      "delta.time.hours",
+      "delta.time.days",
+      "Directory",
+      "FileName"
     )
   # remove duplicates if needed
   if (isTRUE(removeDuplicateRecords)) {
@@ -292,7 +293,7 @@ get_record_table <- function(package = NULL,
       dplyr::filter(.data$delta.time.secs == max(.data$delta.time.secs) &
         .data$row_number == max(.data$row_number)) %>%
       dplyr::ungroup() %>%
-      dplyr::select(-.data$row_number)
+      dplyr::select(-"row_number")
   }
   return(record_table)
 }

--- a/R/read_camtrap_dp.R
+++ b/R/read_camtrap_dp.R
@@ -99,7 +99,7 @@ read_camtrap_dp <- function(file = NULL,
   obs_col_names <- names(observations)
   if (all(c("X22", "X23", "X24") %in% names(observations))) {
     observations <- observations %>%
-      dplyr::rename(speed = X22, radius = X23, angle = X24)
+      dplyr::rename(speed = "X22", radius = "X23", angle = "X24")
     message(
       paste("Three extra fields in `observations` interpreted as `speed`,",
             "`radius` and `angle`."
@@ -127,7 +127,7 @@ read_camtrap_dp <- function(file = NULL,
       )
     observations <-
       observations %>%
-      dplyr::relocate(dplyr::one_of(cols_taxon_infos), .after = cameraSetup)
+      dplyr::relocate(dplyr::one_of(cols_taxon_infos), .after = "cameraSetup")
     # Inherit parsing issues from reading
     attr(observations, which = "problems") <- issues_observations
     package$data$observations <- observations

--- a/tests/testthat/test-calc_animal_pos.R
+++ b/tests/testthat/test-calc_animal_pos.R
@@ -93,7 +93,7 @@ testthat::test_that("Right output", {
   # output is exactly the same as animal_positions except for the new columns
   testthat::expect_equal(
     output %>%
-      dplyr::select(-c(.data$radius, .data$angle, .data$frame_count)),
+      dplyr::select(-c(radius, angle, frame_count)),
     animal_positions
   )
 })

--- a/tests/testthat/test-get_record_table.R
+++ b/tests/testthat/test-get_record_table.R
@@ -135,10 +135,10 @@ test_that(
       dplyr::mutate(len = purrr::map_dbl(Directory, function(x) length(x))) %>%
       dplyr::left_join(mica$data$observations %>%
         dplyr::select(
-          .data$observationID,
-          .data$timestamp,
-          .data$scientificName,
-          .data$sequenceID
+          observationID,
+          timestamp,
+          scientificName,
+          sequenceID
         ),
       by = c(
         "DateTimeOriginal" = "timestamp",
@@ -147,7 +147,7 @@ test_that(
       )
     n_media <-
       mica$data$media %>%
-      dplyr::group_by(sequenceID) %>%
+      dplyr::group_by(.data$sequenceID) %>%
       dplyr::count()
     output <- output %>%
       dplyr::left_join(n_media,


### PR DESCRIPTION
This PR aims to follow the changes in dplyr 1.1.0.

1. 777e12b6c05bc3fa8e34a1ac648f34bb06406e10: do not use `dplyr::na_if()` for replacing 0 with NA over all the data.frame (see bullet point referring to this function in https://dplyr.tidyverse.org/news/index.html#vctrs-1-1-0 and https://github.com/tidyverse/dplyr/issues/6329)
2. 8f1c2bf57698679bf250136a9a2448a3051f9e91: do not use `.data` in tidyselect expressions (`select()`, `rename()`, `relocate()`) as it generates warnings. Use `"colname"` syntax instead. In this way no notes about "no visible binding for global variable" arise. See https://dplyr.tidyverse.org/articles/programming.html#eliminating-r-cmd-check-notes. 
3. 8f1c2bf57698679bf250136a9a2448a3051f9e91 (same commit as 2): add `multiple = "all"` in a `left_join()` to avoid warning (we expect multiple matches of course). See https://www.tidyverse.org/blog/2023/01/dplyr-1-1-0-joins/#multiple-matches
4. Update `DESCRIPTION` by explicit version 1.1.0 of dplyr dependency (064bfee9bbb3b8f440599ea985fe87211e359066), adding @PietrH as contributor to the list of authors (955162b16de933735ea01920a7bcb170c1456731) and bumping version number (fb1ac9b882015f0625bb27350d2b589d020cf7b9)