### PR TITLE
Trigger checks after each commit PR ready for review

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-    types: [ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     branches: [main]
     
@@ -13,6 +13,8 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
+    if: github.event.pull_request.draft == false
+    
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-    types: [ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   release:
     types: [published]
   workflow_dispatch:
@@ -15,6 +15,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -6,7 +6,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-    types: [ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     branches: [main]
 
@@ -14,6 +14,7 @@ name: test-coverage
 
 jobs:
   test-coverage:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR #227 didn't work as wished: commits of an open PR ready for review didn't trigger the automatic checks. Only the switch from draft to PR triggered such checks, which is not enough.

Solution here implemented comes from this GitHub discussion comment: https://github.com/orgs/community/discussions/25722#discussioncomment-3248917

It seems also that the workflow dispatch trigger works, i.e. the `if: github.event.pull_request.draft == false` in the jobs doesn't skip the action when it is manually triggered. I have just checked by triggering the R-CMD-check action on this PR with status draft, see https://github.com/inbo/camtraptor/actions/runs/5543168228/workflow