### PR TITLE
Write orcids as https in `write_eml()`

### DIFF
--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -185,7 +185,7 @@ write_eml <- function(package,
     organizationName = .$organization, # Discouraged by EML, but used by IPT
     email = .$email,
     userId = if (!is.na(.$orcid)) {
-      list(directory = "http://orcid.org/", .$orcid)
+      list(directory = "https://orcid.org/", .$orcid)
     } else {
       NULL
     },

--- a/man/get_effort.Rd
+++ b/man/get_effort.Rd
@@ -36,7 +36,7 @@ A tibble data frame with following columns:
 \itemize{
 \item \code{deploymentID}: Deployment unique identifier.
 \item \code{effort}: Effort expressed in the unit passed by parameter \code{unit}.
-\item \code{unit}:Tthe unit used to express the effort.
+\item \code{unit}: The unit used to express the effort.
 One of the values available for parameter \code{unit}.
 \item \code{effort_duration}: A duration object (duration is a class from lubridate
 package).

--- a/man/get_record_table.Rd
+++ b/man/get_record_table.Rd
@@ -38,7 +38,7 @@ For two records to be considered independent, the second one must be at
 least \code{minDeltaTime} minutes after the last independent record of the same
 species (\code{deltaTimeComparedTo = "lastIndependentRecord"}), or
 \code{minDeltaTime} minutes after the last record (\code{deltaTimeComparedTo = "lastRecord"}).
-If \code{minDeltaTime} is 0, \code{deltaTimeComparedTo} must be \code{NULL} (deafult).}
+If \code{minDeltaTime} is 0, \code{deltaTimeComparedTo} must be \code{NULL} (default).}
 
 \item{removeDuplicateRecords}{Logical.
 If there are several records of the same species at the same station at
@@ -80,7 +80,7 @@ Calculates the record table from a camera trap data package and so tabulating
 species records.
 The record table is a concept developed within the camtrapR package, see
 \href{https://jniedballa.github.io/camtrapR/articles/camtrapr3.html}{this article}.
-See also the function documentation for \href{https://jniedballa.github.io/camtrapR/reference/recordTable.html}{camtraptR::recordTable()}.
+See also the function documentation for \href{https://jniedballa.github.io/camtrapR/reference/recordTable.html}{camtrapR::recordTable()}.
 \strong{Note}: All dates and times are expressed in UTC format.
 }
 \examples{

--- a/tests/testthat/_snaps/write_eml.md
+++ b/tests/testthat/_snaps/write_eml.md
@@ -83,7 +83,7 @@
       phone: ~
       positionName: ~
       userId:
-        directory: http://orcid.org/
+        directory: https://orcid.org/
         '': 0000-0002-8442-8025
       
       $dataset$creator[[6]]
@@ -540,7 +540,7 @@
           organizationName: Research Institute for Nature and Forest (INBO)
           electronicMailAddress: peter.desmet@inbo.be
           userId:
-            directory: http://orcid.org/
+            directory: https://orcid.org/
             userId: 0000-0002-8442-8025
         - individualName:
             givenName: Dennis


### PR DESCRIPTION
Fixes #160

I changed a single character in `write_eml()`, and updated the snapshots. When updating the documentation: 7edcee01d34314a132c52c96ce47d7c74afeea4c, `get_effort.Rd` and `get_effort_table.Rd` updated.