### PR TITLE
Remove small typo and improve sentence

### DIFF
--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,4 +1,4 @@
-test_that("check_package() returns depreciation warning on datapkg argument", {
+test_that("check_package() returns deprecation warning on datapkg argument", {
   expect_warning(
     check_package(datapkg = mica, function_name = "function_name_here"),
     regexp = "The `datapkg` argument of `function_name_here()` is deprecated as of camtraptor 0.16.0.",

--- a/vignettes/visualize-deployment-features.Rmd
+++ b/vignettes/visualize-deployment-features.Rmd
@@ -245,7 +245,7 @@ A message about deployment with zero observations is also returned to the R cons
 
 ```{r show_deployments_without_observations_or_without_known_species}
 # create data package with one deployment with 0 obs and one delpoyment with
-# obsevations of unknown species
+# observations of unknown species
 unknown_species_vs_no_obs <- mica
 unknown_species_vs_no_obs$data$observations <- 
   unknown_species_vs_no_obs$data$observations %>% 
@@ -293,7 +293,7 @@ map_dep(
 
 ### Use a specific icon and color for zero values
 
-You can pass to `zero_value_icon_url` argument the URL to an icon and to `zero_values_icon_size` the size in pixels of such icon. There are several icon libraries you can choose from. A library with many free icons is [icons8](https://icons8.com/). Here, an example with the icon of Fry from Futurama animation series, colour style, and size 50:
+You can pass to `zero_value_icon_url` argument the URL to an icon and to `zero_values_icon_size` the size in pixels of such icon. There are several icon libraries you can choose from. A library with many free icons is [icons8](https://icons8.com/). Here, an example with the icon of Fry from Futurama animation series and icon size 50:
 
 ```{r fry_futurama}
 map_dep(


### PR DESCRIPTION
Typos are everywhere, it seems. This small PR is just an attempt to remove one of them and improve a sentence as well. Nothing more than that.