### PR TITLE
268 add news.md

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,7 +28,6 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.5.0'}
           - {os: ubuntu-latest,   r: '3.6.3'}
           - {os: windows-latest, r: '3.6.3'}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,8 +28,8 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.6.3'}
-          - {os: windows-latest, r: '3.6.3'}
+          - {os: ubuntu-latest,   r: '3.6.0'}
+          - {os: windows-latest, r: '3.6.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,7 +28,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.6.0'}
+          - {os: ubuntu-latest,   r: '3.6.3'}
           - {os: windows-latest, r: '3.6.0'}
 
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Description: Read, explore and visualize Camera Trap Data Packages (Camtrap DP).
 License: MIT + file LICENSE
 BugReports: https://github.com/inbo/camtraptor/issues
 Depends: 
-    R (>= 3.6.3)
+    R (>= 3.6.0)
 Imports:
     assertthat,
     dplyr (>= 1.1.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Description: Read, explore and visualize Camera Trap Data Packages (Camtrap DP).
 License: MIT + file LICENSE
 BugReports: https://github.com/inbo/camtraptor/issues
 Depends: 
-    R (>= 3.5.0)
+    R (>= 3.6.3)
 Imports:
     assertthat,
     dplyr (>= 1.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,5 +4,3 @@ This is a major new release with a number of breaking changes.
 
 * Added a `NEWS.md` file to track changes to the package.
 * Add new functions: `deployments()`, `observations()` and `media()` that make it easier to retreive the tables of the same name from a camtrap dp object. (#232)
-* `write_dwc()` is now faster (#192)
-* The package is no longer dependent on `DBI` or `RSQLite`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,5 +2,4 @@
 
 This is a major new release with a number of breaking changes. 
 
-* Added a `NEWS.md` file to track changes to the package.
-* Add new functions: `deployments()`, `observations()` and `media()` that make it easier to retreive the tables of the same name from a camtrap dp object. (#232)
+* New functions `deployments()`, `observations()` and `media()` make it easier to retrieve table of same name from camtrap-dp object (#232).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# camtraptor 1.0.0
+
+* Added a `NEWS.md` file to track changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
 # camtraptor 1.0.0
 
+This is a major new release with a number of breaking changes. 
+
 * Added a `NEWS.md` file to track changes to the package.
+* Add new functions: `deployments()`, `observations()` and `media()` that make it easier to retreive the tables of the same name from a camtrap dp object. (#232)
+* `write_dwc()` is now faster (#192)
+* The package is no longer dependent on `DBI` or `RSQLite`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ You can install the development version of camtraptor from [GitHub](https://gith
 devtools::install_github("inbo/camtraptor")
 ```
 
-While we support older versions of R up to 3.5, we recommend using R 4.0.0 or higher.
+While we support older versions of R up to 3.6.3, we recommend using R 4.0.0 or higher.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can install the development version of camtraptor from
 devtools::install_github("inbo/camtraptor")
 ```
 
-While we support older versions of R up to 3.5, we recommend using R
+While we support older versions of R up to 3.6.3, we recommend using R
 4.0.0 or higher.
 
 ## Example

--- a/man/apply_filter_predicate.Rd
+++ b/man/apply_filter_predicate.Rd
@@ -24,14 +24,14 @@ deployments.
 \examples{
 # and
 apply_filter_predicate(
-  mica$data$deployments,
+  deployments(mica),
   verbose = TRUE,
   pred_gte("latitude", 51.28),
   pred_lt("longitude", 3.56)
 )
 # Equivalent of
 apply_filter_predicate(
-  mica$data$deployments,
+  deployments(mica),
   verbose = TRUE,
   pred_and(
     pred_gte("latitude", 51.28),
@@ -42,7 +42,7 @@ apply_filter_predicate(
 
 # or
 apply_filter_predicate(
-  mica$data$deployments,
+  deployments(mica),
   verbose = TRUE,
   pred_or(
     pred_gte("latitude", 51.28),


### PR DESCRIPTION
Fixes #268

Using the [`NEWS.md` from frictionless](https://github.com/frictionlessdata/frictionless-r/blob/main/NEWS.md) as inspiration, I've added a NEWS.md with items from #244 and #207. I used `usethis::use_news_md()`.

I suggest we update `NEWS.md` iteratively as we bring more changes to the v1.0 branch.