### PR TITLE
259 datapkg argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,3 +3,4 @@
 This is a major new release with a number of breaking changes. 
 
 * New functions `deployments()`, `observations()` and `media()` make it easier to retrieve table of same name from camtrap-dp object (#232).
+* The `datapkg` argument is now retired and no longer available. Please use the `package` argument instead.

--- a/R/check_package.R
+++ b/R/check_package.R
@@ -8,25 +8,12 @@
 #' - `deployments`
 #'
 #' @param package Camera trap data package
-#' @param datapkg Deprecated. Use `package` instead.
 #' @param media Has the `media` resource been loaded while reading the data
 #'   package? Default: `FALSE`.
 #' @return `TRUE` or error.
 #' @noRd
 check_package <- function(package = NULL,
-                          datapkg = NULL,
-                          function_name,
                           media = FALSE) {
-  if (lifecycle::is_present(datapkg) & !is.null(datapkg)) {
-    lifecycle::deprecate_warn(
-      when = "0.16.0",
-      what = paste0(function_name, "(datapkg = )"),
-      with = paste0(function_name, "(package = )")
-    )
-    if (is.null(package)) {
-      package <- datapkg
-    }
-  }
   # check media arg
   assertthat::assert_that(
     media %in% c(TRUE, FALSE),

--- a/R/check_species.R
+++ b/R/check_species.R
@@ -36,7 +36,7 @@ check_species <- function(package = NULL,
                           species,
                           arg_name = "species") {
   # Check camera trap data package
-  check_package(package, datapkg, "check_species")
+  check_package(package)
   
   assertthat::assert_that(
     !is.null(species) & length(species) > 0,

--- a/R/check_species.R
+++ b/R/check_species.R
@@ -8,7 +8,6 @@
 #' @param species Character vector with scientific or vernacular names.
 #' @param arg_name Character with argument name to return in error message
 #'   Default: "species".
-#' @param datapkg Deprecated. Use `package` instead.
 #' @return A character vector with the correspondent scientific names.
 #' @family validation functions
 #' @importFrom dplyr %>% .data
@@ -35,8 +34,7 @@
 #' }
 check_species <- function(package = NULL,
                           species,
-                          arg_name = "species",
-                          datapkg = lifecycle::deprecated()) {
+                          arg_name = "species") {
   # Check camera trap data package
   check_package(package, datapkg, "check_species")
   

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -50,6 +50,7 @@ get_cam_op <- function(package = NULL,
   
   # Check that station_col is a single string
   assertthat::assert_that(assertthat::is.string(station_col))
+  
   # Check that station_col is one of the columns in deployments
   assertthat::assert_that(
     station_col %in% names(deployments(package)),

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -23,8 +23,6 @@
 #'   returned by [camtrapR::cameraOperation()](
 #'   https://jniedballa.github.io/camtrapR/reference/cameraOperation.html).
 #'   Default: `FALSE`.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... filter predicates for filtering on deployments.
 #' @return A matrix.
 #'   Row names always indicate the station ID.
@@ -46,8 +44,7 @@
 get_cam_op <- function(package = NULL,
                        ...,
                        station_col = "locationName",
-                       use_prefix = FALSE,
-                       datapkg = lifecycle::deprecated()) {
+                       use_prefix = FALSE) {
   # check camera trap data package
   check_package(package, datapkg, "get_cam_op")
   if (is.null(package) & !is.name(datapkg)) {

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -46,10 +46,10 @@ get_cam_op <- function(package = NULL,
                        station_col = "locationName",
                        use_prefix = FALSE) {
   # check camera trap data package
-  check_package(package, datapkg, "get_cam_op")
   if (is.null(package) & !is.name(datapkg)) {
     package <- datapkg
   }
+  check_package(package)
   
   # Check that station_col is a single string
   assertthat::assert_that(assertthat::is.string(station_col))

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -46,9 +46,6 @@ get_cam_op <- function(package = NULL,
                        station_col = "locationName",
                        use_prefix = FALSE) {
   # check camera trap data package
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
   check_package(package)
   
   # Check that station_col is a single string

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -34,8 +34,6 @@
 #'   year as a period of 365 days.
 #' @param unit Character, the time unit to use while returning custom effort.
 #'   One of: `hour` (default), `day`.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... filter predicates
 #' @return A tibble data frame with following columns:
 #'   - `begin`: Begin date of the interval the effort is calculated over.
@@ -90,8 +88,7 @@ get_custom_effort <- function(package = NULL,
                               start = NULL,
                               end = NULL,
                               group_by = NULL,
-                              unit = "hour",
-                              datapkg = lifecycle::deprecated()) {
+                              unit = "hour") {
   # define possible unit values
   units <- c("hour", "day")
 
@@ -117,9 +114,6 @@ get_custom_effort <- function(package = NULL,
 
   # check camera trap data package
   check_package(package, datapkg, "get_custom_effort")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
   
   # get deployments
   deployments <- deployments(package)

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -113,7 +113,7 @@ get_custom_effort <- function(package = NULL,
   check_value(group_by, group_bys, "group_by", null_allowed = TRUE)
 
   # check camera trap data package
-  check_package(package, datapkg, "get_custom_effort")
+  check_package(package)
   
   # get deployments
   deployments <- deployments(package)

--- a/R/get_effort.R
+++ b/R/get_effort.R
@@ -12,8 +12,6 @@
 #'   - `day`
 #'   - `month`
 #'   - `year`
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... filter predicates
 #' @return A tibble data frame with following columns:
 #'   - `deploymentID`: Deployment unique identifier.
@@ -33,8 +31,7 @@
 #' get_effort(mica, unit = "day")
 get_effort <- function(package = NULL,
                        ...,
-                       unit = "hour",
-                       datapkg = lifecycle::deprecated()) {
+                       unit = "hour") {
   # define possible unit values
   units <- c("second", "minute", "hour", "day", "month", "year")
 
@@ -42,11 +39,8 @@ get_effort <- function(package = NULL,
   check_value(unit, units, "unit", null_allowed = FALSE)
 
   # check camera trap data package
-  check_package(package, datapkg, "get_effort")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
-  
+  check_package(package)
+
   # apply filtering
   package$data$deployments <- apply_filter_predicate(
     df = deployments(package),

--- a/R/get_n_individuals.R
+++ b/R/get_n_individuals.R
@@ -18,8 +18,6 @@
 #'   on, e.g. `"adult"` or `c("subadult", "adult")`.
 #'   If `NULL` (default) all observations of all life stage classes are taken
 #'   into account.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... filter predicates for filtering on deployments
 #' @return A tibble data frame with the following columns:
 #' - `deploymentID`: Deployment unique identifier.
@@ -64,13 +62,9 @@ get_n_individuals <- function(package = NULL,
                               ...,
                               species = "all",
                               sex = NULL,
-                              life_stage = NULL,
-                              datapkg = lifecycle::deprecated()) {
+                              life_stage = NULL) {
   # check input data package
   check_package(package, datapkg, "get_n_individuals")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
   
   # avoid to call variables like column names to make life easier using filter()
   sex_value <- sex

--- a/R/get_n_individuals.R
+++ b/R/get_n_individuals.R
@@ -64,7 +64,7 @@ get_n_individuals <- function(package = NULL,
                               sex = NULL,
                               life_stage = NULL) {
   # check input data package
-  check_package(package, datapkg, "get_n_individuals")
+  check_package(package)
   
   # avoid to call variables like column names to make life easier using filter()
   sex_value <- sex

--- a/R/get_n_obs.R
+++ b/R/get_n_obs.R
@@ -18,8 +18,6 @@
 #'   on, e.g. `"adult"` or `c("subadult", "adult")`.
 #'   If `NULL` (default) all observations of all life stage classes are taken
 #'   into account.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... Filter predicates for filtering on deployments
 #' @return A tibble data frame with the following columns:
 #' - `deploymentID`: Deployment unique identifier.
@@ -61,13 +59,9 @@ get_n_obs <- function(package = NULL,
                       ...,
                       species = "all",
                       sex = NULL,
-                      life_stage = NULL,
-                      datapkg = lifecycle::deprecated()) {
+                      life_stage = NULL) {
   # check input data package
-  check_package(package, datapkg, "get_n_obs")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
+  check_package(package)
   
   # avoid to call variables like column names to make life easier using filter()
   sex_value <- sex

--- a/R/get_n_species.R
+++ b/R/get_n_species.R
@@ -5,8 +5,6 @@
 #' @param package Camera trap data package object, as returned by
 #'   `read_camtrap_dp()`.
 #' @param ... Filter predicates for filtering on deployments.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @return A tibble data frame with the following columns:
 #'   - `deploymentID`: Deployment unique identifier.
 #'   - `n`: Number of observed and identified species.
@@ -20,13 +18,10 @@
 #' # Get number of species for deployments with latitude >= 51.18
 #' get_n_species(mica, pred_gte("latitude", 51.18))
 get_n_species <- function(package = NULL,
-                          ...,
-                          datapkg = lifecycle::deprecated()) {
+                          ...) {
   # check input data package
-  check_package(package, datapkg, "get_n_species")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
+  check_package(package)
+  
   # extract observations and deployments
   observations <- observations(package)
   deployments <- deployments(package)

--- a/R/get_rai.R
+++ b/R/get_rai.R
@@ -17,7 +17,6 @@
 #' @param life_stage Character vector defining the life stage class to filter
 #'   on, e.g. `"adult"` or `c("subadult", "adult")`. If `NULL` (default) all
 #'   observations of all life stage classes are taken into account.
-#' @param datapkg Deprecated. Use `package` instead.
 #' @param ... Filter predicates for filtering on deployments.
 #' @return A tibble data frame with the following columns: - `deploymentID`:
 #'   Deployment unique identifier. - `scientificName`: Scientific name. - `rai`:
@@ -55,13 +54,9 @@ get_rai <- function(package = NULL,
                     ...,
                     species = "all",
                     sex = NULL,
-                    life_stage = NULL,
-                    datapkg = lifecycle::deprecated()) {
+                    life_stage = NULL) {
   # check camera trap data package
   check_package(package, datapkg, "get_rai")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
   
   get_rai_primitive(package, ...,
     use = "n_obs",

--- a/R/get_rai.R
+++ b/R/get_rai.R
@@ -56,7 +56,7 @@ get_rai <- function(package = NULL,
                     sex = NULL,
                     life_stage = NULL) {
   # check camera trap data package
-  check_package(package, datapkg, "get_rai")
+  check_package(package)
   
   get_rai_primitive(package, ...,
     use = "n_obs",
@@ -88,8 +88,6 @@ get_rai <- function(package = NULL,
 #'   on, e.g. `"adult"` or `c("subadult", "adult")`.
 #'   If `NULL` (default) all observations of all life stage classes are taken
 #'   into account.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... Filter predicates for filtering on deployments.
 #' @return A tibble data frame with the following columns:
 #'   - `deploymentID`: Deployment unique identifier.
@@ -130,13 +128,9 @@ get_rai_individuals <- function(package = NULL,
                                 ...,
                                 species = "all",
                                 sex = NULL,
-                                life_stage = NULL,
-                                datapkg = lifecycle::deprecated()) {
+                                life_stage = NULL) {
   # check camera trap data package
-  check_package(package, datapkg, "get_rai_individuals")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
+  check_package(package)
   
   get_rai_primitive(package, ...,
     use = "n_individuals",

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -30,8 +30,6 @@
 #' @param removeDuplicateRecords Logical.
 #'   If there are several records of the same species at the same station at
 #'   exactly the same time, show only one?
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... Filter predicates for filtering on deployments
 #' @return A tibble data frame containing species records and additional
 #'   information about stations, date, time and further metadata, such as
@@ -99,13 +97,9 @@ get_record_table <- function(package = NULL,
                              exclude = NULL,
                              minDeltaTime = 0,
                              deltaTimeComparedTo = NULL,
-                             removeDuplicateRecords = TRUE,
-                             datapkg = lifecycle::deprecated()) {
+                             removeDuplicateRecords = TRUE) {
   # check data package
   check_package(package, datapkg, "get_record_table", media = TRUE)
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
   
   # check stationCol is a valid column name
   assertthat::assert_that(

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -99,7 +99,7 @@ get_record_table <- function(package = NULL,
                              deltaTimeComparedTo = NULL,
                              removeDuplicateRecords = TRUE) {
   # check data package
-  check_package(package, datapkg, "get_record_table", media = TRUE)
+  check_package(package, media = TRUE)
   
   # check stationCol is a valid column name
   assertthat::assert_that(

--- a/R/get_scientific_name.R
+++ b/R/get_scientific_name.R
@@ -33,6 +33,7 @@
 get_scientific_name <- function(package = NULL,
                                 vernacular_name) {
   # Check camera trap data package
+  check_package(package)
   
   all_sn_vn <- get_species(package)
 

--- a/R/get_scientific_name.R
+++ b/R/get_scientific_name.R
@@ -8,8 +8,6 @@
 #' @param package Camera trap data package object, as returned by
 #'   `read_camtrap_dp()`.
 #' @param vernacular_name Character vector with input vernacular name(s).
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @family exploration functions
 #' @return Character vector of scientific name(s).
 #' @importFrom dplyr .data %>%
@@ -33,12 +31,8 @@
 #' get_scientific_name(mica, c("Castor fiber", "wilde eend"))
 #' }
 get_scientific_name <- function(package = NULL,
-                                vernacular_name,
-                                datapkg = lifecycle::deprecated()) {
-  check_package(package, datapkg, "get_scientific_name")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
+                                vernacular_name) {
+  # Check camera trap data package
   
   all_sn_vn <- get_species(package)
 

--- a/R/get_scientific_name.R
+++ b/R/get_scientific_name.R
@@ -35,13 +35,14 @@ get_scientific_name <- function(package = NULL,
   # Check camera trap data package
   check_package(package)
   
+  # Get scientific names for check
   all_sn_vn <- get_species(package)
 
-  # get vernacular names for check
+  # Get vernacular names for check
   all_vn <-
     all_sn_vn %>%
     dplyr::select(dplyr::starts_with("vernacularName"))
-  # check validity vernacular_name param
+  # Check validity vernacular_name param
   check_value(
     arg = tolower(vernacular_name),
     options = unlist(all_vn) %>% tolower(),

--- a/R/get_species.R
+++ b/R/get_species.R
@@ -12,7 +12,7 @@
 #' get_species(mica)
 get_species <- function(package = NULL) {
   # Check camera trap data package
-  check_package(package, datapkg, "get_species", media = FALSE)
+  check_package(package, media = FALSE)
 
   # Get taxonomic information from package metadata
   if (!"taxonomic" %in% names(package)) {

--- a/R/get_species.R
+++ b/R/get_species.R
@@ -4,21 +4,16 @@
 #'
 #' @param package Camera trap data package object, as returned by
 #'   `read_camtrap_dp()`.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @return A tibble data frame with all scientific names and vernacular names of
 #'   the identified species.
 #' @family exploration functions
 #' @export
 #' @examples
 #' get_species(mica)
-get_species <- function(package = NULL, datapkg = lifecycle::deprecated()) {
+get_species <- function(package = NULL) {
   # Check camera trap data package
   check_package(package, datapkg, "get_species", media = FALSE)
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
-  
+
   # Get taxonomic information from package metadata
   if (!"taxonomic" %in% names(package)) {
     return(NULL)

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -103,8 +103,6 @@
 #'   value (`relative_scale` = `TRUE`) or `max_scale` (`relative_scale`
 #'   = `FALSE`).
 #'   Default: `c(10, 50)`.
-#' @param datapkg Deprecated.
-#'   Use `package` instead.
 #' @param ... Filter predicates for subsetting deployments.
 #' @return Leaflet map.
 #' @family visualization functions
@@ -348,14 +346,10 @@ map_dep <- function(package = NULL,
                     na_values_icon_size = 10,
                     relative_scale = TRUE,
                     max_scale = NULL,
-                    radius_range = c(10, 50),
-                    datapkg = lifecycle::deprecated()) {
+                    radius_range = c(10, 50)) {
 
   # check camera trap data package
   check_package(package, datapkg, "map_dep")
-  if (is.null(package) & !is.name(datapkg)) {
-    package <- datapkg
-  }
   
   # define possible feature values
   features <- c(

--- a/R/map_dep.R
+++ b/R/map_dep.R
@@ -349,7 +349,7 @@ map_dep <- function(package = NULL,
                     radius_range = c(10, 50)) {
 
   # check camera trap data package
-  check_package(package, datapkg, "map_dep")
+  check_package(package)
   
   # define possible feature values
   features <- c(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -164,7 +164,6 @@ labelFormat_scale <- function(max_scale = NULL,
 #'
 #' @param package Camera trap data package object, as returned by
 #'   `read_camtrap_dp()`.
-#' @param datapkg Deprecated. Use `package` instead.
 #' @param ... Filter predicates for filtering on deployments
 #' @return A tibble data frame with deployments not linked to any observations.
 #' @family exploration functions
@@ -173,11 +172,10 @@ labelFormat_scale <- function(max_scale = NULL,
 #' @examples
 #' get_dep_no_obs(mica)
 get_dep_no_obs <- function(package = NULL,
-                           ...,
-                           datapkg = lifecycle::deprecated()) {
+                           ...) {
 
   # check input camera trap data package
-  check_package(package, datapkg, "get_dep_no_obs")
+  check_package(package)
 
   # extract observations and deployments
   observations <- observations(package)

--- a/man/apply_filter_predicate.Rd
+++ b/man/apply_filter_predicate.Rd
@@ -24,14 +24,14 @@ deployments.
 \examples{
 # and
 apply_filter_predicate(
-  mica$data$deployments,
+  deployments(mica),
   verbose = TRUE,
   pred_gte("latitude", 51.28),
   pred_lt("longitude", 3.56)
 )
 # Equivalent of
 apply_filter_predicate(
-  mica$data$deployments,
+  deployments(mica),
   verbose = TRUE,
   pred_and(
     pred_gte("latitude", 51.28),
@@ -42,7 +42,7 @@ apply_filter_predicate(
 
 # or
 apply_filter_predicate(
-  mica$data$deployments,
+  deployments(mica),
   verbose = TRUE,
   pred_or(
     pred_gte("latitude", 51.28),

--- a/man/check_species.Rd
+++ b/man/check_species.Rd
@@ -4,12 +4,7 @@
 \alias{check_species}
 \title{Check scientific or vernacular name(s)}
 \usage{
-check_species(
-  package = NULL,
-  species,
-  arg_name = "species",
-  datapkg = lifecycle::deprecated()
-)
+check_species(package = NULL, species, arg_name = "species")
 }
 \arguments{
 \item{package}{Camera trap data package object, as returned by
@@ -19,8 +14,6 @@ check_species(
 
 \item{arg_name}{Character with argument name to return in error message
 Default: "species".}
-
-\item{datapkg}{Deprecated. Use \code{package} instead.}
 }
 \value{
 A character vector with the correspondent scientific names.

--- a/man/get_cam_op.Rd
+++ b/man/get_cam_op.Rd
@@ -8,8 +8,7 @@ get_cam_op(
   package = NULL,
   ...,
   station_col = "locationName",
-  use_prefix = FALSE,
-  datapkg = lifecycle::deprecated()
+  use_prefix = FALSE
 )
 }
 \arguments{
@@ -25,9 +24,6 @@ Default: \code{"locationName"}.}
 If \code{TRUE} the returned row names will start with prefix \code{"Station"} as
 returned by \href{https://jniedballa.github.io/camtrapR/reference/cameraOperation.html}{camtrapR::cameraOperation()}.
 Default: \code{FALSE}.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A matrix.

--- a/man/get_custom_effort.Rd
+++ b/man/get_custom_effort.Rd
@@ -10,8 +10,7 @@ get_custom_effort(
   start = NULL,
   end = NULL,
   group_by = NULL,
-  unit = "hour",
-  datapkg = lifecycle::deprecated()
+  unit = "hour"
 )
 }
 \arguments{
@@ -49,9 +48,6 @@ year as a period of 365 days.}
 
 \item{unit}{Character, the time unit to use while returning custom effort.
 One of: \code{hour} (default), \code{day}.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame with following columns:

--- a/man/get_effort.Rd
+++ b/man/get_effort.Rd
@@ -4,12 +4,7 @@
 \alias{get_effort}
 \title{Get effort}
 \usage{
-get_effort(
-  package = NULL,
-  ...,
-  unit = "hour",
-  datapkg = lifecycle::deprecated()
-)
+get_effort(package = NULL, ..., unit = "hour")
 }
 \arguments{
 \item{package}{Camera trap data package object, as returned by
@@ -27,9 +22,6 @@ One of:
 \item \code{month}
 \item \code{year}
 }}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame with following columns:

--- a/man/get_n_individuals.Rd
+++ b/man/get_n_individuals.Rd
@@ -9,8 +9,7 @@ get_n_individuals(
   ...,
   species = "all",
   sex = NULL,
-  life_stage = NULL,
-  datapkg = lifecycle::deprecated()
+  life_stage = NULL
 )
 }
 \arguments{
@@ -33,9 +32,6 @@ account.}
 on, e.g. \code{"adult"} or \code{c("subadult", "adult")}.
 If \code{NULL} (default) all observations of all life stage classes are taken
 into account.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame with the following columns:

--- a/man/get_n_obs.Rd
+++ b/man/get_n_obs.Rd
@@ -4,14 +4,7 @@
 \alias{get_n_obs}
 \title{Get number of observations for each deployment}
 \usage{
-get_n_obs(
-  package = NULL,
-  ...,
-  species = "all",
-  sex = NULL,
-  life_stage = NULL,
-  datapkg = lifecycle::deprecated()
-)
+get_n_obs(package = NULL, ..., species = "all", sex = NULL, life_stage = NULL)
 }
 \arguments{
 \item{package}{Camera trap data package object, as returned by
@@ -33,9 +26,6 @@ account.}
 on, e.g. \code{"adult"} or \code{c("subadult", "adult")}.
 If \code{NULL} (default) all observations of all life stage classes are taken
 into account.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame with the following columns:

--- a/man/get_n_species.Rd
+++ b/man/get_n_species.Rd
@@ -4,16 +4,13 @@
 \alias{get_n_species}
 \title{Get number of identified species for each deployment}
 \usage{
-get_n_species(package = NULL, ..., datapkg = lifecycle::deprecated())
+get_n_species(package = NULL, ...)
 }
 \arguments{
 \item{package}{Camera trap data package object, as returned by
 \code{read_camtrap_dp()}.}
 
 \item{...}{Filter predicates for filtering on deployments.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame with the following columns:

--- a/man/get_rai.Rd
+++ b/man/get_rai.Rd
@@ -4,14 +4,7 @@
 \alias{get_rai}
 \title{Get Relative Abundance Index (RAI)}
 \usage{
-get_rai(
-  package = NULL,
-  ...,
-  species = "all",
-  sex = NULL,
-  life_stage = NULL,
-  datapkg = lifecycle::deprecated()
-)
+get_rai(package = NULL, ..., species = "all", sex = NULL, life_stage = NULL)
 }
 \arguments{
 \item{package}{Camera trap data package object, as returned by
@@ -30,8 +23,6 @@ classes are taken into account.}
 \item{life_stage}{Character vector defining the life stage class to filter
 on, e.g. \code{"adult"} or \code{c("subadult", "adult")}. If \code{NULL} (default) all
 observations of all life stage classes are taken into account.}
-
-\item{datapkg}{Deprecated. Use \code{package} instead.}
 }
 \value{
 A tibble data frame with the following columns: - \code{deploymentID}:

--- a/man/get_rai_individuals.Rd
+++ b/man/get_rai_individuals.Rd
@@ -9,8 +9,7 @@ get_rai_individuals(
   ...,
   species = "all",
   sex = NULL,
-  life_stage = NULL,
-  datapkg = lifecycle::deprecated()
+  life_stage = NULL
 )
 }
 \arguments{
@@ -32,9 +31,6 @@ account.}
 on, e.g. \code{"adult"} or \code{c("subadult", "adult")}.
 If \code{NULL} (default) all observations of all life stage classes are taken
 into account.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame with the following columns:

--- a/man/get_record_table.Rd
+++ b/man/get_record_table.Rd
@@ -11,8 +11,7 @@ get_record_table(
   exclude = NULL,
   minDeltaTime = 0,
   deltaTimeComparedTo = NULL,
-  removeDuplicateRecords = TRUE,
-  datapkg = lifecycle::deprecated()
+  removeDuplicateRecords = TRUE
 )
 }
 \arguments{
@@ -43,9 +42,6 @@ If \code{minDeltaTime} is 0, \code{deltaTimeComparedTo} must be \code{NULL} (def
 \item{removeDuplicateRecords}{Logical.
 If there are several records of the same species at the same station at
 exactly the same time, show only one?}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame containing species records and additional

--- a/man/get_scientific_name.Rd
+++ b/man/get_scientific_name.Rd
@@ -4,20 +4,13 @@
 \alias{get_scientific_name}
 \title{Get scientific name for vernacular name}
 \usage{
-get_scientific_name(
-  package = NULL,
-  vernacular_name,
-  datapkg = lifecycle::deprecated()
-)
+get_scientific_name(package = NULL, vernacular_name)
 }
 \arguments{
 \item{package}{Camera trap data package object, as returned by
 \code{read_camtrap_dp()}.}
 
 \item{vernacular_name}{Character vector with input vernacular name(s).}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 Character vector of scientific name(s).

--- a/man/get_species.Rd
+++ b/man/get_species.Rd
@@ -4,14 +4,11 @@
 \alias{get_species}
 \title{Get species}
 \usage{
-get_species(package = NULL, datapkg = lifecycle::deprecated())
+get_species(package = NULL)
 }
 \arguments{
 \item{package}{Camera trap data package object, as returned by
 \code{read_camtrap_dp()}.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 A tibble data frame with all scientific names and vernacular names of

--- a/man/map_dep.Rd
+++ b/man/map_dep.Rd
@@ -24,8 +24,7 @@ map_dep(
   na_values_icon_size = 10,
   relative_scale = TRUE,
   max_scale = NULL,
-  radius_range = c(10, 50),
-  datapkg = lifecycle::deprecated()
+  radius_range = c(10, 50)
 )
 }
 \arguments{
@@ -152,9 +151,6 @@ The upper value is used for the deployment(s) with the highest feature
 value (\code{relative_scale} = \code{TRUE}) or \code{max_scale} (\code{relative_scale}
 = \code{FALSE}).
 Default: \code{c(10, 50)}.}
-
-\item{datapkg}{Deprecated.
-Use \code{package} instead.}
 }
 \value{
 Leaflet map.

--- a/tests/testthat/test-check_package.R
+++ b/tests/testthat/test-check_package.R
@@ -1,11 +1,3 @@
-test_that("check_package() returns deprecation warning on datapkg argument", {
-  expect_warning(
-    check_package(datapkg = mica, function_name = "function_name_here"),
-    regexp = "The `datapkg` argument of `function_name_here()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})
-
 test_that("check_package() returns error when package is not a list", {
   expect_error(
     check_package("not a list!"),

--- a/tests/testthat/test-get_cam_op.R
+++ b/tests/testthat/test-get_cam_op.R
@@ -166,14 +166,3 @@ test_that("filtering predicates are allowed and work well", {
   )
   expect_equal(rownames(filtered_cam_op_matrix), "Mica Viane")
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_cam_op(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_cam_op()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -180,14 +180,3 @@ test_that("check effort and unit values", {
   # unit value is equal to day if unit value is set to "day"
   expect_equal(unique(tot_effort_days$unit), "day")
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_custom_effort(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_custom_effort()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_effort.R
+++ b/tests/testthat/test-get_effort.R
@@ -75,14 +75,3 @@ testthat::test_that("get_effort returns the right number of rows", {
     n_all_deployments
   )
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_effort(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_effort()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_n_individuals.R
+++ b/tests/testthat/test-get_n_individuals.R
@@ -247,14 +247,3 @@ test_that("error returned if life stage or sex is not present", {
   expect_error(get_n_individuals(mica, life_stage = "bad"))
   expect_error(get_n_individuals(mica, sex = "bad"))
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_n_individuals(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_n_individuals()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_n_obs.R
+++ b/tests/testthat/test-get_n_obs.R
@@ -280,14 +280,3 @@ test_that("Filter by date of deployments via predicates works correctly", {
     dplyr::arrange(deploymentID, scientificName)
   expect_equal(obs_filtered, obs_filtered_man)
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_n_obs(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_n_obs()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_n_species.R
+++ b/tests/testthat/test-get_n_species.R
@@ -44,14 +44,3 @@ test_that("get_n_species returns NA for deployments without observations", {
   n_species <- suppressMessages(get_n_species(package = no_obs))
   expect_true(is.na(n_species[n_species$deploymentID == dep_no_obs,]$n))
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_n_species(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_n_species()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_rai.R
+++ b/tests/testthat/test-get_rai.R
@@ -104,14 +104,3 @@ test_that("life_stage filters data correctly", {
     ignore_attr = TRUE
   )
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_rai(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_rai()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_rai_individuals.R
+++ b/tests/testthat/test-get_rai_individuals.R
@@ -108,14 +108,3 @@ test_that("life_stage filters data correctly", {
     ignore_attr = TRUE
   )
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_rai_individuals(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_rai_individuals()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_record_table.R
+++ b/tests/testthat/test-get_record_table.R
@@ -194,14 +194,3 @@ test_that("filtering predicates are allowed and work well", {
     dplyr::pull(locationName)
   testthat::expect_identical(stations, stations_calculate)
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_record_table(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_record_table()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_scientific_name.R
+++ b/tests/testthat/test-get_scientific_name.R
@@ -18,14 +18,3 @@ test_that("Functions works case insensitively", {
   sc_names <- get_scientific_name(mica, c("beeCH MArten"))
   expect_equal(sc_names, c("Martes foina"))
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_scientific_name(datapkg = mica, vernacular_name = "beech marten")
-    ),
-    regexp = "The `datapkg` argument of `get_scientific_name()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-get_species.R
+++ b/tests/testthat/test-get_species.R
@@ -71,14 +71,3 @@ test_that("function works fine with missing vernacular name slots", {
       dplyr::pull(vernacularNames.nl))
   )
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      get_species(datapkg = mica)
-    ),
-    regexp = "The `datapkg` argument of `get_species()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})

--- a/tests/testthat/test-map_dep.R
+++ b/tests/testthat/test-map_dep.R
@@ -226,14 +226,3 @@ test_that("map_dep() returns a leaflet", {
   expect_no_error(map_dep(mica, feature = "n_species"))
   expect_no_message(map_dep(mica, feature = "n_species"))
 })
-
-test_that("Argument datapkg is deprecated: warning returned", {
-  expect_warning(
-    rlang::with_options(
-      lifecycle_verbosity = "warning",
-      map_dep(datapkg = mica, feature = "n_obs")
-    ),
-    regexp = "The `datapkg` argument of `map_dep()` is deprecated as of camtraptor 0.16.0.",
-    fixed = TRUE
-  )
-})


### PR DESCRIPTION
Fixes #259 

## Major TODO:

- [x] Entirely remove `datapkg` as a deprecated alternative argument for `package` in all functions where it is used
- [x] Remove `function_name` from `check_package()`, see this comment https://github.com/inbo/camtraptor/pull/223#discussion_r1269162502

### Steps
Remove `datapkg` argument from:

- [x] check_package()
- [x] check_species()
- [x] get_cam_op()
- [x] get_custom_effort()
- [x] get_effort()
- [x] get_n_individuals()
- [x] get_n_obs()
- [x] get_n_species()
- [x] get_rai()
- [x] get_record_table()
- [x] get_scientific_name()
- [x] get_species()
- [x] map_dep()
- [x] get_dep_no_obs() (zzz.R)

And tests for:

- [x] check_package()
- [x] get_cam_op()
- [x] get_custom_effort()
- [x] get_effort()
- [x] get_n_individuals()
- [x] get_n_obs()
- [x] get_n_species()
- [x] get_rai_individuals()
- [x] get_rai()
- [x] get_record_table()
- [x] get_scientific_name()
- [x] get_species()
- [x] map_dep()

Also adapt `check_package()` call to remove function_name use (used for lifecyle warning) in:

- [x] check_species()
- [x] get_custom_effort()
- [x] get_effort()
- [x] get_n_individuals()
- [x] get_n_obs()
- [x] get_n_species()
- [x] get_rai()
- [x] get_rai_individuals() (get_rai.R)
- [x] get_record_table()
- [x] get_scientific_name()
- [x] get_species()
- [x] map_dep()
- [x] get_dep_no_obs() (zzz.R)

Documentation
- [x] remove any mention to `datapkg` in roxygen documentation
- [x] run `devtools::document()`
