### PR TITLE
Use calendar values in `get_custom_effort`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,9 +28,8 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.5.0'}
           - {os: ubuntu-latest,   r: '3.6.3'}
-          - {os: windows-latest, r: '3.6.3'}
+          - {os: windows-latest, r: '3.6.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.20.0
+Version: 0.20.1
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -92,13 +92,13 @@ get_custom_effort <- function(package = NULL,
                               group_by = NULL,
                               unit = "hour",
                               datapkg = lifecycle::deprecated()) {
-  # define possible unit values
+  # Define possible unit values
   units <- c("hour", "day")
 
-  # check unit
+  # Check unit
   check_value(unit, units, "unit", null_allowed = FALSE)
 
-  # define possible group_by values
+  # Define possible group_by values
   group_bys <- c(
     "day",
     "week",
@@ -112,19 +112,19 @@ get_custom_effort <- function(package = NULL,
     lubridate::dyears(x = 1)
   )
 
-  # check group_by
+  # Check group_by
   check_value(group_by, group_bys, "group_by", null_allowed = TRUE)
 
-  # check camera trap data package
+  # Check camera trap data package
   check_package(package, datapkg, "get_custom_effort")
   if (is.null(package) & !is.name(datapkg)) {
     package <- datapkg
   }
   
-  # get deployments
+  # Get deployments
   deployments <- package$data$deployments
 
-  # camera operation matrix with filter(s) on deployments
+  # Camera operation matrix with filter(s) on deployments
   cam_op <- get_cam_op(package, ..., station_col = "deploymentID")
 
   # Sum effort over all deployments for each day  (in day units)
@@ -135,7 +135,7 @@ get_custom_effort <- function(package = NULL,
     sum_effort = sum_effort
   )
 
-  # check start and end are both dates
+  # Check start and end are both dates
   assertthat::assert_that(
     is.null(start) | all(class(start) == "Date"),
     msg = glue::glue(
@@ -190,7 +190,7 @@ get_custom_effort <- function(package = NULL,
       )
     }
   } else {
-    # set start to date of the earliest deployment
+    # Set start to date of the earliest deployment
     start <- sum_effort$date[1]
   }
   # Check end is not later than end last deployment date.
@@ -206,30 +206,30 @@ get_custom_effort <- function(package = NULL,
       )
     }
   } else {
-    # set end to date of the latest deployment
+    # Set end to date of the latest deployment
     end <- sum_effort$date[nrow(sum_effort)]
   }
   
-  # check start earlier than end
+  # Check start earlier than end
   assertthat::assert_that(start <= end,
     msg = "`start` must be earlier than `end`."
   )
 
-  # create df with all dates from start to end
+  # Create df with all dates from start to end
   dates_df <- dplyr::tibble(date = seq(start, end, by = "days"))
 
-  # join dates_df to sum_effort
+  # Join dates_df to sum_effort
   sum_effort <-
     dates_df %>%
     dplyr::left_join(sum_effort, by = "date")
 
-  # filter by start and end date
+  # Filter by start and end date
   sum_effort <-
     sum_effort %>%
     dplyr::filter(.data$date >= start & .data$date <= end)
 
   if (is.null(group_by)) {
-    # total effort (days) over all deployments
+    # Calculate total effort (days) over all deployments
     sum_effort <-
       sum_effort %>%
       dplyr::summarise(
@@ -245,14 +245,14 @@ get_custom_effort <- function(package = NULL,
       dplyr::summarise(effort = sum(.data$sum_effort, na.rm = TRUE))
   }
 
-  # transform effort to hours if needed
+  # Transform effort to hours if needed
   if (unit == "hour") {
     sum_effort <-
       sum_effort %>%
       dplyr::mutate(effort = .data$effort * 24)
   }
 
-  # add unit column and adjust column order
+  # Add unit column and adjust column order
   sum_effort %>%
     dplyr::mutate(unit = unit) %>%
     dplyr::select(

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -241,7 +241,7 @@ get_custom_effort <- function(package = NULL,
       sum_effort %>%
       dplyr::mutate(
         begin = lubridate::floor_date(.data$date, unit = group_by)) %>%
-      dplyr::group_by(begin) %>%
+      dplyr::group_by(.data$begin) %>%
       dplyr::summarise(effort = sum(.data$sum_effort, na.rm = TRUE))
   }
 

--- a/man/get_custom_effort.Rd
+++ b/man/get_custom_effort.Rd
@@ -43,9 +43,9 @@ end date among all deployments.}
 \item{group_by}{Character, one of \code{"day"}, \code{"week"}, \code{"month"}, \code{"year"}.
 The effort is calculated at the interval rate defined in \code{group_by}.
 Default: \code{NULL}: no grouping, i.e. the entire interval from \code{start} to
-\code{end} is taken into account as a whole.
-A week is defined as a period of 7 days, a month as a period of 30 days, a
-year as a period of 365 days.}
+\code{end} is taken into account as a whole. Calendar values are used, i.e.
+grouping by year will calculate the effort from Jan 1st up to Dec 31st for
+each year.}
 
 \item{unit}{Character, the time unit to use while returning custom effort.
 One of: \code{hour} (default), \code{day}.}
@@ -63,7 +63,7 @@ A tibble data frame with following columns:
 }
 \description{
 Gets the custom effort (deployment duration) for a custom time window and a
-specific time interval such as day or month. The custom effort is also
+specific time interval such as day, week, month or year. The custom effort is also
 calculated over all deployments, although filtering predicates can be applied
 as well. This function calls \code{get_cam_op()} internally.
 }

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -10,7 +10,7 @@ test_that("get_custom_effort returns error for invalid group_by value", {
 
 test_that("get_custom_effort returns error for start not a Date", {
   expect_error(get_custom_effort(mica, start = "2021-01-01"))
-  # no datetime allowed
+  # No datetime allowed
   expect_error(
     get_custom_effort(
       mica, 
@@ -24,7 +24,7 @@ test_that("get_custom_effort returns error for start not a Date", {
 
 test_that("get_custom_effort returns error for end not a Date", {
   expect_error(get_custom_effort(mica, end = "2021-01-01"))
-  # no datetime allowed
+  # No datetime allowed
   expect_error(
     get_custom_effort(mica,
                       end = lubridate::as_datetime("2021-12-05 22:25:01 CET")),
@@ -126,35 +126,35 @@ test_that("get_custom_effort returns warning if end set too late", {
 
 
 test_that("right columns, cols types, right relative number of rows", {
-  # right cols and col types: no groups
+  # Right cols and col types: no groups
   tot_effort <- get_custom_effort(mica)
   expect_named(tot_effort, expected = c("begin", "effort", "unit"))
   expect_s3_class(tot_effort$begin, "Date")
   expect_type(tot_effort$effort, "double")
   expect_type(tot_effort$unit, "character")
 
-  # right cols and col types: group by year
+  # Right cols and col types: group by year
   effort_by_year <- get_custom_effort(mica, group_by = "year")
   expect_true(
     all(colnames(effort_by_year) == c("begin", "effort", "unit"))
   )
 
-  # right cols and col types: group by month
+  # Right cols and col types: group by month
   effort_by_month <- get_custom_effort(mica, group_by = "month")
   expect_named(effort_by_month, expected = c("begin", "effort", "unit"))
 
-  # right cols and col types: group by week
+  # Right cols and col types: group by week
   effort_by_week <- get_custom_effort(mica, group_by = "week")
   expect_named(effort_by_week, expected = c("begin", "effort", "unit"))
 
-  # right cols and col types: group by day
+  # Right cols and col types: group by day
   effort_by_day <- get_custom_effort(mica, group_by = "day")
   expect_named(effort_by_day, expected = c("begin", "effort", "unit"))
 
-  # number of rows is equal to 1 if group_by is NULL
+  # Number of rows is equal to 1 if group_by is NULL
   expect_identical(nrow(tot_effort), 1L)
 
-  # number of rows with grouping by year is equal to number of calendar years
+  # Number of rows with grouping by year is equal to number of calendar years
   first_day <- min(mica$data$deployments$start)
   last_day <- max(mica$data$deployments$end)
   n_years <- length(seq(
@@ -164,7 +164,7 @@ test_that("right columns, cols types, right relative number of rows", {
   )
   expect_identical(nrow(effort_by_year), n_years)
 
-  # number of rows with grouping by month is equal to number of calendar months
+  # Number of rows with grouping by month is equal to number of calendar months
   n_months <- length(seq(
     lubridate::floor_date(first_day, unit = "months"),
     lubridate::floor_date(last_day, unit = "months"),
@@ -172,7 +172,7 @@ test_that("right columns, cols types, right relative number of rows", {
   )
   expect_identical(nrow(effort_by_month), n_months)
 
-  # number of rows with grouping by week is equal to number of calendar weeks
+  # Number of rows with grouping by week is equal to number of calendar weeks
   n_weeks <- length(seq(
     lubridate::floor_date(first_day, unit = "weeks"),
     lubridate::floor_date(last_day, unit = "weeks"),
@@ -180,28 +180,28 @@ test_that("right columns, cols types, right relative number of rows", {
   )
   expect_identical(nrow(effort_by_week), n_weeks)
 
-  # number of rows for daily groups is higher than for weekly groups
+  # Number of rows for daily groups is higher than for weekly groups
   expect_gte(nrow(effort_by_day), nrow(effort_by_week))
-  # number of rows for weekly groups is higher than for monthly groups
+  # Number of rows for weekly groups is higher than for monthly groups
   expect_gte(nrow(effort_by_week), nrow(effort_by_month))
-  # number of rows for monthly groups is higher than for yearly groups
+  # Number of rows for monthly groups is higher than for yearly groups
   expect_gte(nrow(effort_by_month), nrow(effort_by_year))
 
-  # number of rows with start not NULL is lower than with start = NULL
+  # Number of rows with start not NULL is lower than with start = NULL
   set_start <- get_custom_effort(mica,
     start = as.Date("2020-08-01"),
     group_by = "month"
   )
   expect_lt(nrow(set_start), nrow(effort_by_month))
 
-  # number of rows with end not NULL is lower than with end = NULL
+  # Number of rows with end not NULL is lower than with end = NULL
   set_end <- get_custom_effort(mica,
     end = as.Date("2021-01-01"),
     group_by = "month"
   )
   expect_lt(nrow(set_end), nrow(effort_by_month))
 
-  # number of rows with both specific start and end is the lowest
+  # Number of rows with both specific start and end is the lowest
   set_start_end <- get_custom_effort(mica,
     start = as.Date("2020-08-01"),
     end = as.Date("2021-01-01"),
@@ -213,7 +213,7 @@ test_that("right columns, cols types, right relative number of rows", {
 
 test_that("check effort and unit values", {
   tot_effort <- get_custom_effort(mica)
-  # filtering deployments reduces effort value
+  # Filtering deployments reduces effort value
   filter_deploys <- suppressMessages(
     get_custom_effort(mica,
       pred_gte("latitude", 51.18),
@@ -222,13 +222,13 @@ test_that("check effort and unit values", {
   )
   expect_lt(filter_deploys$effort, tot_effort$effort)
 
-  # effort in hours is higher than effort in days
+  # Effort in hours is higher than effort in days
   tot_effort_days <- get_custom_effort(mica, unit = "day")
   expect_gt(tot_effort$effort, tot_effort_days$effort)
 
-  # unit value is equal to hour if default unit value is used
+  # Unit value is equal to hour if default unit value is used
   expect_identical(unique(tot_effort$unit), "hour")
-  # unit value is equal to day if unit value is set to "day"
+  # Unit value is equal to day if unit value is set to "day"
   expect_identical(unique(tot_effort_days$unit), "day")
 })
 

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -64,7 +64,7 @@ test_that(
     expect_error(get_custom_effort(mica, end = as.Date("1900-04-05")),
                  regexp = paste0(
                    "`end` value is set too early. ",
-                   "`end` value must be not earlier than the start of the ", 
+                   "`end` value must be not earlier than the start of the ",
                    "earliest deployment: 2019-10-09."),
                  fixed = TRUE
     )

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -1,8 +1,8 @@
 test_that("get_custom_effort returns error for invalid group_by value", {
   expect_error(get_custom_effort(mica, group_by = "bad_value"),
-               regexp = paste0("Invalid value for group_by parameter: ", 
+               regexp = paste0("Invalid value for group_by parameter: ",
                                "bad_value.\n",
-                               "Valid inputs are: NULL, day, week, month ", 
+                               "Valid inputs are: NULL, day, week, month ",
                                "and year."),
                fixed = TRUE
   )

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -185,7 +185,6 @@ test_that("right columns, cols types, right relative number of rows", {
   
   # number of rows for weekly groups is higher than for monthly groups
   expect_gte(nrow(effort_by_week), nrow(effort_by_month))
-  
   # number of rows for monthly groups is higher than for yearly groups
   expect_gte(nrow(effort_by_month), nrow(effort_by_year))
 

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -90,7 +90,7 @@ test_that("get_custom_effort returns warning if start set too early", {
       group_by = "day"
     )
   )
-  expect_equal(
+  expect_identical(
     start_too_early$warnings,
     paste0(
       "`start` value is set too early. ",
@@ -98,7 +98,7 @@ test_that("get_custom_effort returns warning if start set too early", {
       "deployment: 2019-10-09."
     )
   )
-  expect_equal(
+  expect_identical(
     start_too_early$result$begin[1],
     lubridate::as_date(min(mica$data$deployments$start))
   )
@@ -111,14 +111,14 @@ test_that("get_custom_effort returns warning if end set too late", {
       group_by = "day"
     )
   )
-  expect_equal(
+  expect_identical(
     end_too_late$warnings,
     paste0(
       "`end` value is set too late. ",
       "`end` authomatically set to end date of latest deployment: 2021-04-18."
     )
   )
-  expect_equal(
+  expect_identical(
     end_too_late$result$begin[nrow(end_too_late$result)],
     lubridate::as_date(max(mica$data$deployments$end))
   )
@@ -152,7 +152,7 @@ test_that("right columns, cols types, right relative number of rows", {
   expect_named(effort_by_day, expected = c("begin", "effort", "unit"))
 
   # number of rows is equal to 1 if group_by is NULL
-  expect_equal(nrow(tot_effort), 1)
+  expect_identical(nrow(tot_effort), 1L)
 
   # number of rows with grouping by year is equal to number of calendar years
   first_day <- min(mica$data$deployments$start)
@@ -162,7 +162,7 @@ test_that("right columns, cols types, right relative number of rows", {
     lubridate::floor_date(last_day, unit = "years"),
     by = "years")
   )
-  expect_equal(nrow(effort_by_year), n_years)
+  expect_identical(nrow(effort_by_year), n_years)
 
   # number of rows with grouping by month is equal to number of calendar months
   n_months <- length(seq(
@@ -170,7 +170,7 @@ test_that("right columns, cols types, right relative number of rows", {
     lubridate::floor_date(last_day, unit = "months"),
     by = "months")
   )
-  expect_equal(nrow(effort_by_month), n_months)
+  expect_identical(nrow(effort_by_month), n_months)
 
   # number of rows with grouping by week is equal to number of calendar weeks
   n_weeks <- length(seq(
@@ -178,7 +178,7 @@ test_that("right columns, cols types, right relative number of rows", {
     lubridate::floor_date(last_day, unit = "weeks"),
     by = "weeks")
   )
-  expect_equal(nrow(effort_by_week), n_weeks)
+  expect_identical(nrow(effort_by_week), n_weeks)
 
   # number of rows for daily groups is higher than for weekly groups
   expect_gte(nrow(effort_by_day), nrow(effort_by_week))
@@ -229,9 +229,9 @@ test_that("check effort and unit values", {
   expect_gt(tot_effort$effort, tot_effort_days$effort)
 
   # unit value is equal to hour if default unit value is used
-  expect_equal(unique(tot_effort$unit), "hour")
+  expect_identical(unique(tot_effort$unit), "hour")
   # unit value is equal to day if unit value is set to "day"
-  expect_equal(unique(tot_effort_days$unit), "day")
+  expect_identical(unique(tot_effort_days$unit), "day")
 })
 
 test_that("Argument datapkg is deprecated: warning returned", {

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -1,24 +1,50 @@
 test_that("get_custom_effort returns error for invalid group_by value", {
-  expect_error(get_custom_effort(mica, group_by = "bad_value"))
+  expect_error(get_custom_effort(mica, group_by = "bad_value"),
+               regexp = paste0("Invalid value for group_by parameter: ", 
+                               "bad_value.\n",
+                               "Valid inputs are: NULL, day, week, month ", 
+                               "and year."),
+               fixed = TRUE
+  )
 })
 
 test_that("get_custom_effort returns error for start not a Date", {
   expect_error(get_custom_effort(mica, start = "2021-01-01"))
   # no datetime allowed
-  expect_error(get_custom_effort(mica, start = lubridate::as_datetime("2021-12-05 22:25:01 CET")))
+  expect_error(
+    get_custom_effort(
+      mica, 
+      start = lubridate::as_datetime("2021-12-05 22:25:01 CET")),
+    regexp = paste0("`start` must be `NULL` or an object of class Date. ",
+                    "Did you forget to convert a string to Date with ",
+                    "`as.Date()`?"),
+    fixed = TRUE
+  )
 })
 
 test_that("get_custom_effort returns error for end not a Date", {
   expect_error(get_custom_effort(mica, end = "2021-01-01"))
   # no datetime allowed
-  expect_error(get_custom_effort(mica, end = lubridate::as_datetime("2021-12-05 22:25:01 CET")))
+  expect_error(
+    get_custom_effort(mica,
+                      end = lubridate::as_datetime("2021-12-05 22:25:01 CET")),
+    regexp = paste0("`end` must be `NULL` or an object of class Date. ",
+                    "Did you forget to convert a string to Date with ",
+                    "`as.Date()`?"),
+    fixed = TRUE
+  )
 })
 
 test_that("get_custom_effort returns error if end earlier than start", {
-  expect_error(get_custom_effort(mica,
-    start = as.Date("2021-01-01"),
-    end = as.Date("1990-01-01")
-  ))
+  expect_error(
+    get_custom_effort(mica, 
+                      start = as.Date("2021-01-01"), 
+                      end = as.Date("1990-01-01")),
+    regexp = paste0("`end` value is set too early. `end` value must be not ", 
+                    "earlier than the start of the earliest deployment: ", 
+                    "2019-10-09."),
+    fixed = TRUE
+  )
 })
 
 test_that(
@@ -28,7 +54,8 @@ test_that(
                  "`start` value is set too late. ",
                  "`start` value must be not later than the end of the latest ",
                  "deployment: 2021-04-18."
-                 )
+                 ),
+               fixed = TRUE
                )
 })
 
@@ -44,8 +71,16 @@ test_that(
   })
 
 test_that("get_custom_effort returns error for invalid effort units", {
-  expect_error(get_custom_effort(mica, unit = "second"))
-  expect_error(get_custom_effort(mica, unit = "year"))
+  expect_error(get_custom_effort(mica, unit = "second"),
+               regexp = paste0("Invalid value for unit parameter: second.\n",
+                               "Valid inputs are: hour and day."),
+               fixed = TRUE
+  )
+  expect_error(get_custom_effort(mica, unit = "year"),
+               regexp = paste0("Invalid value for unit parameter: year.\n",
+                               "Valid inputs are: hour and day."),
+               fixed = TRUE
+  )
 })
 
 test_that("get_custom_effort returns warning if start set too early", {

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -158,7 +158,7 @@ test_that("right columns, cols types, right relative number of rows", {
   first_day <- min(mica$data$deployments$start)
   last_day <- max(mica$data$deployments$end)
   n_years <- length(seq(
-    lubridate::floor_date(first_day, unit = "years"), 
+    lubridate::floor_date(first_day, unit = "years"),
     lubridate::floor_date(last_day, unit = "years"),
     by = "years")
   )

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -174,7 +174,7 @@ test_that("right columns, cols types, right relative number of rows", {
 
   # number of rows with grouping by week is equal to number of calendar weeks
   n_weeks <- length(seq(
-    lubridate::floor_date(first_day, unit = "weeks"), 
+    lubridate::floor_date(first_day, unit = "weeks"),
     lubridate::floor_date(last_day, unit = "weeks"),
     by = "weeks")
   )

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -37,11 +37,11 @@ test_that("get_custom_effort returns error for end not a Date", {
 
 test_that("get_custom_effort returns error if end earlier than start", {
   expect_error(
-    get_custom_effort(mica, 
-                      start = as.Date("2021-01-01"), 
+    get_custom_effort(mica,
+                      start = as.Date("2021-01-01"),
                       end = as.Date("1990-01-01")),
-    regexp = paste0("`end` value is set too early. `end` value must be not ", 
-                    "earlier than the start of the earliest deployment: ", 
+    regexp = paste0("`end` value is set too early. `end` value must be not ",
+                    "earlier than the start of the earliest deployment: ",
                     "2019-10-09."),
     fixed = TRUE
   )

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -21,13 +21,31 @@ test_that("get_custom_effort returns error if end earlier than start", {
   ))
 })
 
+test_that(
+  "get_custom_effort returns error if start later than end of latest deployment", {
+  expect_error(get_custom_effort(mica, start = as.Date("2030-01-01")),
+               regexp = paste0(
+                 "`start` value is set too late. ",
+                 "`start` value must be not later than the end of the latest ",
+                 "deployment: 2021-04-18."
+                 )
+               )
+})
+
+test_that(
+  "get_custom_effort returns error if end earlier than begin of first deployment", {
+    expect_error(get_custom_effort(mica, end = as.Date("1900-04-05")),
+                 regexp = paste0(
+                   "`end` value is set too early. ",
+                   "`end` value must be not earlier than the start of the ", 
+                   "earliest deployment: 2019-10-09."),
+                 fixed = TRUE
+    )
+  })
+
 test_that("get_custom_effort returns error for invalid effort units", {
   expect_error(get_custom_effort(mica, unit = "second"))
   expect_error(get_custom_effort(mica, unit = "year"))
-})
-
-test_that("get_custom_effort returns warning if start set too early", {
-  expect_warning(get_custom_effort(mica, start = as.Date("1990-01-01")))
 })
 
 test_that("get_custom_effort returns warning if start set too early", {
@@ -40,10 +58,9 @@ test_that("get_custom_effort returns warning if start set too early", {
   expect_equal(
     start_too_early$warnings,
     paste0(
-      "`start` is set too early. Earliest deployment start date: 2019-10-09. ",
-      "With the given `group_by` value the earliest start possible is ",
-      "2019-10-09. `start` is set to start date of earliest deployment: ",
-      "2019-10-09."
+      "`start` value is set too early. ",
+      "`start` authomatically set to start date of earliest ",
+      "deployment: 2019-10-09."
     )
   )
   expect_equal(
@@ -62,10 +79,8 @@ test_that("get_custom_effort returns warning if end set too late", {
   expect_equal(
     end_too_late$warnings,
     paste0(
-      "`end` set too late. Latest deployment end date: 2021-04-18. ",
-      "With the given `group_by` value the latest end possible is ",
-      "2021-04-18. `end` is set to end date of latest deployment: ",
-      "2021-04-18."
+      "`end` value is set too late. ",
+      "`end` authomatically set to end date of latest deployment: 2021-04-18."
     )
   )
   expect_equal(
@@ -118,33 +133,49 @@ test_that("right columns, cols types, right relative number of rows", {
   # number of rows is equal to 1 if group_by is NULL
   expect_equal(nrow(tot_effort), 1)
 
-  # number of rows with grouping by year is equal to number of days divided by
-  # 365
+  # number of rows with grouping by year is equal to number of calendar years
   first_day <- min(mica$data$deployments$start)
   last_day <- max(mica$data$deployments$end)
-  n_years <- as.numeric(last_day - first_day) %/% 365 + 1
+  n_years <- length(seq(
+    lubridate::floor_date(first_day, unit = "years"), 
+    lubridate::floor_date(last_day, unit = "years"),
+    by = "years")
+  )
   expect_equal(nrow(effort_by_year), n_years)
 
-  # number of rows with grouping by month is equal to number of days divided by
-  # 30
-  n_months <- as.numeric(last_day - first_day) %/% 30 + 1
+  # number of rows with grouping by month is equal to number of calendar months
+  n_months <- length(seq(
+    lubridate::floor_date(first_day, unit = "months"), 
+    lubridate::floor_date(last_day, unit = "months"),
+    by = "months")
+  )
   expect_equal(nrow(effort_by_month), n_months)
 
-  # number of rows with grouping by week is equal to number of days divided by 7
-  n_weeks <- as.numeric(last_day - first_day) %/% 7 + 1
+  # number of rows with grouping by week is equal to number of calendar weeks
+  n_weeks <- length(seq(
+    lubridate::floor_date(first_day, unit = "weeks"), 
+    lubridate::floor_date(last_day, unit = "weeks"),
+    by = "weeks")
+  )
   expect_equal(nrow(effort_by_week), n_weeks)
 
   # number of rows for daily groups is higher than for weekly groups
   expect_gte(nrow(effort_by_day), nrow(effort_by_week))
+  
+  # number of rows for weekly groups is higher than for monthly groups
+  expect_gte(nrow(effort_by_week), nrow(effort_by_month))
+  
+  # number of rows for monthly groups is higher than for yearly groups
+  expect_gte(nrow(effort_by_month), nrow(effort_by_year))
 
-  # number of rows with start defined lower than for entire datapackage
+  # number of rows with start not NULL is lower than with start = NULL
   set_start <- get_custom_effort(mica,
-    start = as.Date("2021-01-01"),
+    start = as.Date("2020-08-01"),
     group_by = "month"
   )
   expect_lt(nrow(set_start), nrow(effort_by_month))
 
-  # number of rows with end defined lower than for entire datapackage
+  # number of rows with end not NULL is lower than with end = NULL
   set_end <- get_custom_effort(mica,
     end = as.Date("2021-01-01"),
     group_by = "month"
@@ -157,7 +188,8 @@ test_that("right columns, cols types, right relative number of rows", {
     end = as.Date("2021-01-01"),
     group_by = "month"
   )
-  expect_lt(nrow(set_end), nrow(effort_by_month))
+  expect_lt(nrow(set_start_end), nrow(set_end))
+  expect_lt(nrow(set_start_end), nrow(set_start))
 })
 
 test_that("check effort and unit values", {

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -128,10 +128,10 @@ test_that("get_custom_effort returns warning if end set too late", {
 test_that("right columns, cols types, right relative number of rows", {
   # right cols and col types: no groups
   tot_effort <- get_custom_effort(mica)
-  expect_true(all(colnames(tot_effort) == c("begin", "effort", "unit")))
-  expect_equal(class(tot_effort$begin), "Date")
-  expect_equal(class(tot_effort$effort), "numeric")
-  expect_equal(class(tot_effort$unit), "character")
+  expect_named(tot_effort, expected = c("begin", "effort", "unit"))
+  expect_s3_class(tot_effort$begin, "Date")
+  expect_type(tot_effort$effort, "double")
+  expect_type(tot_effort$unit, "character")
 
   # right cols and col types: group by year
   effort_by_year <- get_custom_effort(mica, group_by = "year")

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -106,29 +106,15 @@ test_that("right columns, cols types, right relative number of rows", {
 
   # right cols and col types: group by month
   effort_by_month <- get_custom_effort(mica, group_by = "month")
-  expect_true(
-    all(colnames(effort_by_month) == c("begin", "effort", "unit"))
-  )
+  expect_named(effort_by_month, expected = c("begin", "effort", "unit"))
 
   # right cols and col types: group by week
   effort_by_week <- get_custom_effort(mica, group_by = "week")
-  expect_true(
-    all(
-      colnames(effort_by_week) == c("begin", "effort", "unit")
-    )
-  )
+  expect_named(effort_by_week, expected = c("begin", "effort", "unit"))
 
   # right cols and col types: group by day
   effort_by_day <- get_custom_effort(mica, group_by = "day")
-  expect_true(
-    all(
-      colnames(effort_by_day) == c(
-        "begin",
-        "effort",
-        "unit"
-      )
-    )
-  )
+  expect_named(effort_by_day, expected = c("begin", "effort", "unit"))
 
   # number of rows is equal to 1 if group_by is NULL
   expect_equal(nrow(tot_effort), 1)

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -182,7 +182,6 @@ test_that("right columns, cols types, right relative number of rows", {
 
   # number of rows for daily groups is higher than for weekly groups
   expect_gte(nrow(effort_by_day), nrow(effort_by_week))
-  
   # number of rows for weekly groups is higher than for monthly groups
   expect_gte(nrow(effort_by_week), nrow(effort_by_month))
   # number of rows for monthly groups is higher than for yearly groups

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -166,7 +166,7 @@ test_that("right columns, cols types, right relative number of rows", {
 
   # number of rows with grouping by month is equal to number of calendar months
   n_months <- length(seq(
-    lubridate::floor_date(first_day, unit = "months"), 
+    lubridate::floor_date(first_day, unit = "months"),
     lubridate::floor_date(last_day, unit = "months"),
     by = "months")
   )


### PR DESCRIPTION
This PR solves #219 by using calendar weeks/months/years for grouping while calculating the effort.

Unit-tests in `test-get_custom_effort()` have been not only updated, but also sensibly improved partly based on testthat things learned while working on #272 thanks to @PietrH.