### PR TITLE
Fix two `write_eml()` issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.21.0.9000
+Version: 0.22.0
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.21.0
+Version: 0.21.0.9000
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# camtraptor 0.22.0
+
+- Fix bug in `write_eml()` for Camtrap DP 1.0 datasets (#290).
+- `read_camtrap_dp()` will now always populate `taxonID` from the 
+  `package.taxonomy` (#290).
+
 # camtraptor 0.21.0
 
 - `read_camtrap_dp()` supports Camtrap DP 1.0 (upcoming Agouti export format) 

--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -167,10 +167,7 @@ write_eml <- function(package,
       )
     }
     # Sort contributors on order in creators
-    contributors <- dplyr::slice(
-      contributors,
-      order_by = order(factor(.data$title, levels = creators))
-    )
+    contributors <- arrange(contributors, factor(title, level = creators))
   }
   creator_list <- purrr::transpose(contributors) # Create list
   message(glue::glue(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -367,19 +367,25 @@ add_taxonomic_info <- function(package) {
   taxon_infos <- dplyr::select(
     taxon_infos,
     dplyr::all_of("scientificName"),
-    dplyr::any_of(c("taxonIDReference",
-                    "taxonRank")),
+    dplyr::any_of(c("taxonID", "taxonIDReference", "taxonRank")),
     dplyr::starts_with("vernacularNames")
   )
-  # add taxon infos to observations
+  # Add taxon infos to observations
   if (!is.null(taxon_infos)) {
     cols_taxon_infos <- names(taxon_infos)
     observations <-
       dplyr::left_join(
         package$data$observations,
         taxon_infos,
-        by  = c("scientificName")
+        by = "scientificName"
       )
+    if ("taxonID.y" %in% colnames(observations)) {
+      # Keep only the taxonID added by join with taxonomy
+      observations <-
+        observations %>%
+        rename("taxonID" = "taxonID.y") %>%
+        select(-"taxonID.x")
+    }
     package$data$observations <- observations
   }
   return(package)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -497,7 +497,8 @@ convert_metadata_to_0.1.6 <- function(package, from = "1.0"){
       "The field `sequenceInterval` is deprecated in version {from}."
     ))
   }
-  package$platform <- package$sources[[1]]$title
+  package$platform <- package$sources[[1]]
+  
   # `title` value of the first contributor with role `rightsHolder`
   package$rightsHolder <- purrr::map_df(package$contributors, unlist) %>%
     dplyr::filter(.data$role == "rightsHolder") %>%


### PR DESCRIPTION
This PR fixes two issues I encountered when running `write_eml()` on a Camtrap DP 1.0 version of the entire MICA dataset.

1. Conversion: move the entire first of `package$sources` to `package$platform`: `write_eml()` couldn't find `platform$path` before because only the title was copied.
2. Use a simpler way to arrange the contributors on a provided order of names. It errored before.
3. Always choose taxonID from taxonomy if available