### PR TITLE
Fix #292

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.22.0
+Version: 0.23.0
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/R/check_species.R
+++ b/R/check_species.R
@@ -47,7 +47,7 @@ check_species <- function(package = NULL,
 
   all_species <-
     get_species(package) %>%
-    dplyr::select(-"taxonID")
+    dplyr::select(-dplyr::any_of(c("taxonID", "taxonIDReference")))
   check_value(
     tolower(species),
     unlist(all_species) %>% tolower(),

--- a/R/check_species.R
+++ b/R/check_species.R
@@ -48,6 +48,7 @@ check_species <- function(package = NULL,
   all_species <-
     get_species(package) %>%
     dplyr::select(-dplyr::any_of(c("taxonID", "taxonIDReference")))
+  
   check_value(
     tolower(species),
     unlist(all_species) %>% tolower(),

--- a/R/check_species.R
+++ b/R/check_species.R
@@ -47,7 +47,7 @@ check_species <- function(package = NULL,
 
   all_species <-
     get_species(package) %>%
-    dplyr::select(-c("taxonID", "taxonIDReference"))
+    dplyr::select(-"taxonID")
   check_value(
     tolower(species),
     unlist(all_species) %>% tolower(),

--- a/R/write_eml.R
+++ b/R/write_eml.R
@@ -167,7 +167,7 @@ write_eml <- function(package,
       )
     }
     # Sort contributors on order in creators
-    contributors <- arrange(contributors, factor(title, level = creators))
+    contributors <- dplyr::arrange(contributors, factor(title, level = creators))
   }
   creator_list <- purrr::transpose(contributors) # Create list
   message(glue::glue(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -383,8 +383,8 @@ add_taxonomic_info <- function(package) {
       # Keep only the taxonID added by join with taxonomy
       observations <-
         observations %>%
-        rename("taxonID" = "taxonID.y") %>%
-        select(-"taxonID.x")
+        dplyr::rename("taxonID" = "taxonID.y") %>%
+        dplyr::select(-"taxonID.x")
     }
     package$data$observations <- observations
   }

--- a/man/get_record_table.Rd
+++ b/man/get_record_table.Rd
@@ -123,7 +123,7 @@ mica_dup$data$observations[4,"sequenceID"] <- mica_dup$data$observations$sequenc
 mica_dup$data$observations[4, "deploymentID"] <- mica_dup$data$observations$deploymentID[3]
 mica_dup$data$observations[4, "timestamp"] <- mica_dup$data$observations$timestamp[3]
 
-# duplicate removed
+# duplicates are removed by default by get_record_table()
 get_record_table(mica_dup)
 
 # duplicate not removed


### PR DESCRIPTION
This PR fixes #292. The column `taxonIDReference` cannot be removed via `dplyr::select()` in `get_species()` as this column is not anymore returned by `check_species()`. The reason is that this column is not anymore filled in metadata of version 1.0.

By using `dplyr::any_of()` we are sure `check_species()` works for both new and old versions of camtrapDP.