### PR TITLE
Add radius and angle to event-based observations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.23.0
+Version: 0.24.0
 Authors@R: c(
     person("Damiano", "Oldoni", email = "damiano.oldoni@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3445-7562")),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -754,13 +754,14 @@ convert_observations_to_0.1.6 <- function(package, from = "1.0") {
     media_observations %>%
     dplyr::filter(!is.na(.data$individualPositionRadius),
                   !is.na(.data$individualPositionAngle)) %>%
-    dplyr::group_by(.data$eventID) %>%
+    dplyr::group_by(.data$eventID, .data$individualID) %>%
     # Take the very first row with the lowest eventStart.
     # Notice that multiple media could have the same value of eventStart
     # Use with_ties = FALSE to be sure to take the very first element.
     dplyr::slice_min(.data$eventStart, n = 1, with_ties = FALSE) %>%
     dplyr::ungroup() %>%
-    dplyr::select(c("eventID", 
+    dplyr::select(c("eventID",
+                    "individualID",
                     "individualPositionRadius", 
                     "individualPositionAngle")) %>%
     dplyr::rename_with(~ paste0("media_", .x),
@@ -773,7 +774,8 @@ convert_observations_to_0.1.6 <- function(package, from = "1.0") {
   
   # Add angle/radius to event based observations if missing
   event_observations <- event_observations %>%
-    dplyr::left_join(obs_first_radius_angle, by = "eventID") %>%
+    dplyr::left_join(obs_first_radius_angle,
+                     by = c("eventID", "individualID")) %>%
     dplyr::mutate(
       individualPositionAngle = dplyr::if_else(
         condition = is.na(.data$individualPositionAngle),

--- a/tests/testthat/test-read_camtrap_dp.R
+++ b/tests/testthat/test-read_camtrap_dp.R
@@ -533,12 +533,24 @@ test_that(
 )
 
 test_that(
+  "read observations v1.0: radius is NA as NA in media based obs too", {
+    expect_true(all(is.na(dp_v1_with_media$data$observations$radius)))
+  }
+)
+
+test_that(
   "read observations v1.0: individualPositionAngle is renamed as angle", {
     expect_false(
       "individualPositionAngle" %in% 
         names(dp_v1_with_media$data$observations)
     )
     expect_true("angle" %in% names(dp_v1_with_media$data$observations))
+  }
+)
+
+test_that(
+  "read observations v1.0: angle is NA as NA in media based obs too", {
+    expect_true(all(is.na(dp_v1_with_media$data$observations$angle)))
   }
 )
 


### PR DESCRIPTION
This PR fixes #291.

During conversion to older version, it takes for each `eventID`-`individualID` the values of `individualPositionRadius` and `individualPositionAngle` where the following holds true:
- `individualPositionRadius` and `individualPositionAngle` are both not NA
- `eventStart` is the lowest one. In case of multiple values with same `eventStart`, the first row is taken (this is more a safety move, as using `individualID` for grouping there shouldn't be multiple values of `eventStart` for each group)

This results in one and only one value of `individualPositionRadius` and `individualPositionAngle` for each `eventID`-`individualID`.

These values are joint to event-based observations based on `eventID`-`individualID`.