### PR TITLE
Adapt `get_custom_effort`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.25.0
+Version: 0.26.0
 Authors@R: c(
     person("Damiano", "Oldoni", , "damiano.oldoni@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3445-7562")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,5 +63,5 @@ Encoding: UTF-8
 LazyData: true
 LazyDataCompression: bzip2
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# camtraptor 0.26.0
+
+- `get_custom_effort()` returns now the effort for each deployment separately (#333). The returned data frame has two new columns: `deploymentID` and `locationName`.
+
 # camtraptor 0.25.0
 
 - `read_camtrap_dp()` detects Camtrap DP version from `package$profile` using 

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -87,6 +87,20 @@
 #' # Applying filter(s), e.g. deployments with latitude >= 51.18, can be
 #' # combined with other arguments
 #' get_custom_effort(mica, pred_gte("latitude", 51.18), group_by = "month")
+#' 
+#' # You can afterwards calculate the total effort over all deployments
+#' library(dplyr)
+#' get_custom_effort(mica, group_by = "year", unit = "day") %>%
+#'   dplyr::filter(effort > 0) %>%
+#'   dplyr::group_by(begin) %>% 
+#'   dplyr::summarise(
+#'     deploymentIDs = list(deploymentID),
+#'     locationNames = list(locationName),
+#'     ndep = length(unique(deploymentID)),
+#'     nloc = length(unique(locationName)),
+#'     effort = sum(effort),
+#'     unit = unique(unit)
+#'   )
 get_custom_effort <- function(package = NULL,
                               ...,
                               start = NULL,

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -163,6 +163,32 @@ get_custom_effort <- function(package = NULL,
   # Get deployments
   deployments <- package$data$deployments
 
+  # Stop function and inform user about deployments with missing `start` date
+  no_start_deployments <- deployments[is.na(deployments$start),]$deploymentID
+  if (length(no_start_deployments) > 0) {
+    stop(
+      glue::glue(
+        "The deployments with the following deploymentID ",
+        "have missing `start` value: ",
+        glue::glue_collapse(no_start_deployments, sep = ", ", last = " and "),
+        "."
+      )
+    )
+  }
+  
+  # Stop function and inform user about deployments with missing `end` date
+  no_end_deployments <- deployments[is.na(deployments$end),]$deploymentID
+  if (length(no_end_deployments) > 0) {
+    stop(
+      glue::glue(
+        "The deployments with the following deploymentID ",
+        "have missing `end` value: ",
+        glue::glue_collapse(no_end_deployments, sep = ", ", last = " and "),
+        "."
+      )
+    )
+  }
+  
   # Camera operation matrix with filter(s) on deployments
   cam_op <- get_cam_op(package, ..., station_col = "deploymentID")
 

--- a/R/get_custom_effort.R
+++ b/R/get_custom_effort.R
@@ -1,9 +1,8 @@
 #' Get custom effort
 #'
-#' Gets the custom effort (deployment duration) for a custom time window and a
-#' specific time interval such as day, week, month or year. The custom effort is also
-#' calculated over all deployments, although filtering predicates can be applied
-#' as well. This function calls `get_cam_op()` internally.
+#' Gets the effort for each deployment and a specific time interval such as day,
+#' week, month or year. A custom time window can also be set up. This function
+#' calls `get_cam_op()` internally.
 #'
 #' @param package Camera trap data package object, as returned by
 #'   `read_camtrap_dp()`.
@@ -38,6 +37,8 @@
 #'   Use `package` instead.
 #' @param ... filter predicates
 #' @return A tibble data frame with following columns:
+#'   - `deploymentID`: Deployment unique identifier.
+#'   - `locationName`: Location name of the deployments.
 #'   - `begin`: Begin date of the interval the effort is calculated over.
 #'   - `effort`: The effort as number.
 #'   - `unit`: Character specifying the effort unit.
@@ -45,46 +46,47 @@
 #' @importFrom dplyr .data %>%
 #' @export
 #' @examples
-#' # A global effort over the entire duration of the project (datapackage)
-#' # measured in hours
+#' # Effort for each deployment over the entire duration of the project
+#' # (datapackage) measured in hours (default)
 #' get_custom_effort(mica)
 #'
-#' # Global effort expressed in days
+#' # Effort for each deployment expressed in days
 #' get_custom_effort(mica, unit = "day")
 #'
-#' # Total effort from a specific start to a specific end
+#' # Effort for each deployment from a specific start to a specific end
 #' get_custom_effort(
 #'   mica,
 #'   start = as.Date("2019-12-15"), # or lubridate::as_date("2019-12-15")
 #'   end = as.Date("2021-01-10")
 #' )
 #'
-#' # Effort at daily interval
+#' # Effort for each deployment at daily interval
 #' get_custom_effort(
 #'   mica,
 #'   group_by = "day"
 #' )
 #'
-#' # Effort at weekly interval
+#' # Effort for each deployment at weekly interval
 #' get_custom_effort(
 #'   mica,
 #'   group_by = "week"
 #' )
 #'
-#' # Effort at monthly interval
+#' # Effort for each deployment at monthly interval
 #' get_custom_effort(
 #'   mica,
 #'   group_by = "month"
 #' )
 #'
-#' # Effort at yearly interval
+#' # Effort for each deployment at yearly interval
 #' get_custom_effort(
 #'   mica,
 #'   group_by = "year"
 #' )
 #'
-#' # Applying filter(s), e.g. deployments with latitude >= 51.18
-#' get_custom_effort(mica, pred_gte("latitude", 51.18))
+#' # Applying filter(s), e.g. deployments with latitude >= 51.18, can be
+#' # combined with other arguments
+#' get_custom_effort(mica, pred_gte("latitude", 51.18), group_by = "month")
 get_custom_effort <- function(package = NULL,
                               ...,
                               start = NULL,

--- a/man/get_custom_effort.Rd
+++ b/man/get_custom_effort.Rd
@@ -56,58 +56,60 @@ Use \code{package} instead.}
 \value{
 A tibble data frame with following columns:
 \itemize{
+\item \code{deploymentID}: Deployment unique identifier.
+\item \code{locationName}: Location name of the deployments.
 \item \code{begin}: Begin date of the interval the effort is calculated over.
 \item \code{effort}: The effort as number.
 \item \code{unit}: Character specifying the effort unit.
 }
 }
 \description{
-Gets the custom effort (deployment duration) for a custom time window and a
-specific time interval such as day, week, month or year. The custom effort is also
-calculated over all deployments, although filtering predicates can be applied
-as well. This function calls \code{get_cam_op()} internally.
+Gets the effort for each deployment and a specific time interval such as day,
+week, month or year. A custom time window can also be set up. This function
+calls \code{get_cam_op()} internally.
 }
 \examples{
-# A global effort over the entire duration of the project (datapackage)
-# measured in hours
+# Effort for each deployment over the entire duration of the project
+# (datapackage) measured in hours (default)
 get_custom_effort(mica)
 
-# Global effort expressed in days
+# Effort for each deployment expressed in days
 get_custom_effort(mica, unit = "day")
 
-# Total effort from a specific start to a specific end
+# Effort for each deployment from a specific start to a specific end
 get_custom_effort(
   mica,
   start = as.Date("2019-12-15"), # or lubridate::as_date("2019-12-15")
   end = as.Date("2021-01-10")
 )
 
-# Effort at daily interval
+# Effort for each deployment at daily interval
 get_custom_effort(
   mica,
   group_by = "day"
 )
 
-# Effort at weekly interval
+# Effort for each deployment at weekly interval
 get_custom_effort(
   mica,
   group_by = "week"
 )
 
-# Effort at monthly interval
+# Effort for each deployment at monthly interval
 get_custom_effort(
   mica,
   group_by = "month"
 )
 
-# Effort at yearly interval
+# Effort for each deployment at yearly interval
 get_custom_effort(
   mica,
   group_by = "year"
 )
 
-# Applying filter(s), e.g. deployments with latitude >= 51.18
-get_custom_effort(mica, pred_gte("latitude", 51.18))
+# Applying filter(s), e.g. deployments with latitude >= 51.18, can be
+# combined with other arguments
+get_custom_effort(mica, pred_gte("latitude", 51.18), group_by = "month")
 }
 \seealso{
 Other exploration functions: 

--- a/man/get_custom_effort.Rd
+++ b/man/get_custom_effort.Rd
@@ -110,6 +110,20 @@ get_custom_effort(
 # Applying filter(s), e.g. deployments with latitude >= 51.18, can be
 # combined with other arguments
 get_custom_effort(mica, pred_gte("latitude", 51.18), group_by = "month")
+
+# You can afterwards calculate the total effort over all deployments
+library(dplyr)
+get_custom_effort(mica, group_by = "year", unit = "day") \%>\%
+  dplyr::filter(effort > 0) \%>\%
+  dplyr::group_by(begin) \%>\% 
+  dplyr::summarise(
+    deploymentIDs = list(deploymentID),
+    locationNames = list(locationName),
+    ndep = length(unique(deploymentID)),
+    nloc = length(unique(locationName)),
+    effort = sum(effort),
+    unit = unique(unit)
+  )
 }
 \seealso{
 Other exploration functions: 

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -1,3 +1,59 @@
+test_that("get_custom_effort() returns error if one or more deployments have NA as `start`", {
+  a <- mica
+  # One NA as ´start´
+  a$data$deployments$start[1] <- NA
+  expect_error(
+    get_custom_effort(a),
+    paste0("The deployments with the following deploymentID have missing ",
+           "`start` value: 29b7d356-4bb4-4ec4-b792-2af5cc32efa8.")
+  )
+  # Two NAs
+  a$data$deployments$start[3] <- NA
+  expect_error(
+    get_custom_effort(a),
+    paste0("The deployments with the following deploymentID have missing ",
+           "`start` value: 29b7d356-4bb4-4ec4-b792-2af5cc32efa8 and ",
+           "62c200a9-0e03-4495-bcd8-032944f6f5a1.")
+  )
+  # Three NAs
+  a$data$deployments$start[4] <- NA
+  expect_error(
+    get_custom_effort(a),
+    paste0("The deployments with the following deploymentID have missing ",
+           "`start` value: 29b7d356-4bb4-4ec4-b792-2af5cc32efa8, ",
+           "62c200a9-0e03-4495-bcd8-032944f6f5a1 and ",
+           "7ca633fa-64f8-4cfc-a628-6b0c419056d7.")
+  )
+})
+
+test_that("get_custom_effort() returns error if one or more deployments have NA as `end`", {
+  a <- mica
+  # One NA
+  a$data$deployments$end[1] <- NA
+  expect_error(
+    get_custom_effort(a),
+    paste0("The deployments with the following deploymentID have missing ",
+           "`end` value: 29b7d356-4bb4-4ec4-b792-2af5cc32efa8.")
+  )
+  # Two NAs
+  a$data$deployments$end[3] <- NA
+  expect_error(
+    get_custom_effort(a),
+    paste0("The deployments with the following deploymentID have missing ",
+           "`end` value: 29b7d356-4bb4-4ec4-b792-2af5cc32efa8 and ",
+           "62c200a9-0e03-4495-bcd8-032944f6f5a1.")
+  )
+  # Three NAs
+  a$data$deployments$end[4] <- NA
+  expect_error(
+    get_custom_effort(a),
+    paste0("The deployments with the following deploymentID have missing ",
+           "`end` value: 29b7d356-4bb4-4ec4-b792-2af5cc32efa8, ",
+           "62c200a9-0e03-4495-bcd8-032944f6f5a1 and ",
+           "7ca633fa-64f8-4cfc-a628-6b0c419056d7.")
+  )
+})
+
 test_that("get_custom_effort returns error for invalid group_by value", {
   expect_error(
     get_custom_effort(mica, group_by = "bad_value"),

--- a/tests/testthat/test-get_custom_effort.R
+++ b/tests/testthat/test-get_custom_effort.R
@@ -254,6 +254,21 @@ test_that("right columns, cols types, right relative number of rows", {
   expect_lt(nrow(set_start_end), nrow(set_start))
 })
 
+test_that("output get_custom_effort can be manipulated to output get_effort", {
+  # Get effort in days per deployment
+  effort_days <- get_custom_effort(mica)
+  # Total effort via get_effort
+  tot_effort <- get_effort(mica)
+  # Same effort per deployment
+  expect_equal(effort_days$effort, tot_effort$effort)
+  # Columns `deploymentID` and `effort` are equal
+  expect_equal(effort_days$deploymentID, tot_effort$deploymentID)
+  # While grouping per a specific time interval, the sum of effort is equal to total effort as calculated via `get_effort()`
+  effort_days_per_week <- get_custom_effort(mica, group_by = "week")
+  expect_equal(sum(effort_days_per_week$effort), sum(tot_effort$effort))
+})
+
+
 test_that("check effort and unit values", {
   tot_effort <- get_custom_effort(mica)
   # Filtering on deployments reduces number of rows (less deployments)


### PR DESCRIPTION
This PR will solve #333.

Thanks @MartijnUH for the very well description of the requested feature and the code.

I think I adapted `get_custom_effort` as you wished.

Test it hard please 🔨 


Can you please test the PR and so review it? Thanks.
You can install this PR directly in R:

```r
devtools::install_github("inbo/camtraptor", ref = "pull/335/head")
```

Notice that in the example on how to calculate the total effort over all deployments (added as example in function documentation), I needed to add **`dplyr::filter(effort > 0)`** to your provided code, otherwise I get all deployments in `deploymentIDs`, `ndep` and `nloc`:

```r
get_custom_effort(mica, group_by = "year", unit = "day") %>%
  dplyr::filter(effort > 0) %>%
  dplyr::group_by(begin) %>% 
  dplyr::summarise(
    deploymentIDs = list(deploymentID),
    locationNames = list(locationName),
    ndep = length(unique(deploymentID)),
    nloc = length(unique(locationName)),
    effort = sum(effort),
    unit = unique(unit)
  )
```
