### PR TITLE
Add pkgcheck action

### DIFF
--- a/.github/workflows/pkgcheck.yaml
+++ b/.github/workflows/pkgcheck.yaml
@@ -1,0 +1,18 @@
+name: pkgcheck
+
+# This will cancel running jobs once a new run is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  # Manually trigger the Action under Actions/pkgcheck
+  workflow_dispatch:
+
+jobs:
+  pkgcheck:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: ropensci-review-tools/pkgcheck-action@main


### PR DESCRIPTION
Before releasing v1.0, it is useful to run the pkgcheck action to validate the package using [rOpenSci's system](https://docs.ropensci.org/pkgcheck/). Since manually triggered workflows (`workflow_dispatch`) can only be run from the default branch, the action must first be merged into `main`. Once added, pkgcheck can be triggered manually and run against any branch, including the branch `vignettes-and-first-review`.