### PR TITLE
Prevent double coordinates

### DIFF
--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -28,7 +28,7 @@ add_coordinates <- function(x) {
     return(x)
   }
   
-  # add coordinates to observations
+  # Add coordinates to observations
   observations(x) <- observations(x) %>%
     dplyr::left_join(deployments(x) %>% 
                        dplyr::select("deploymentID", "latitude", "longitude"),

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -19,6 +19,9 @@
 #' add_coordinates(x) %>% observations()
 add_coordinates <- function(x) {
   
+  # Check Camera Trap Data Package
+  camtrapdp::check_camtrapdp(x)
+  
   # If coordinates are already present, warn and return x
   if (all(c("latitude", "longitude") %in% colnames(observations(x)))) {
     warning("Coordinates already present in observations. Returning x.")

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -1,16 +1,20 @@
 #' Add deployment coordinates to observations
-#' 
+#'
 #' This function adds deployment coordinates to `observations` based on
 #' `deploymentID`.
 #'
-#' @inheritParams summarize_deployments 
+#' When the `latitude` and `longitude` columns are already present in
+#' `observations`, a warning is issued and the original object is returned
+#' unchanged.
+#'
+#' @inheritParams summarize_deployments
 #' @returns Camera trap data package object, where `observations` is updated by
 #'   appending two new columns: `latitude` and `longitude`
 #' @family transformation functions
 #' @export
 #' @examples
 #' x <- example_dataset()
-#' 
+#'
 #' # Add coordinates to observations
 #' add_coordinates(x) %>% observations()
 add_coordinates <- function(x) {

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -27,6 +27,19 @@ add_coordinates <- function(x) {
     warning("Coordinates are not added because they already present in observations.")
     return(x)
   }
+
+  # If only one of the coordinates is present, warn and return x
+  if (any(c("latitude", "longitude") %in% colnames(observations(x)))) {
+    present_coord <- ifelse(
+      "latitude" %in% colnames(observations(x)),
+      "latitude",
+      "longitude"
+    )
+    warning(glue::glue(
+      "Coordinates are not added because {present_coord} is already present in observations."
+    ))
+    return(x)
+  }
   
   # Add coordinates to observations
   observations(x) <- observations(x) %>%

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -24,7 +24,7 @@ add_coordinates <- function(x) {
   
   # If coordinates are already present, warn and return x
   if (all(c("latitude", "longitude") %in% colnames(observations(x)))) {
-    warning("Coordinates already present in observations. Returning x.")
+    warning("Coordinates are not added because they already present in observations.")
     return(x)
   }
   

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -15,6 +15,12 @@
 #' add_coordinates(x) %>% observations()
 add_coordinates <- function(x) {
   
+  # If coordinates are already present, warn and return x
+  if (all(c("latitude", "longitude") %in% colnames(observations(x)))) {
+    warning("Coordinates already present in observations. Returning x.")
+    return(x)
+  }
+  
   # add coordinates to observations
   observations(x) <- observations(x) %>%
     dplyr::left_join(deployments(x) %>% 

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -3,7 +3,7 @@
 #' This function adds deployment coordinates to `observations` based on
 #' `deploymentID`.
 #'
-#' When the `latitude` and `longitude` columns are already present in
+#' When the `latitude` and/or the `longitude` columns are already present in
 #' `observations`, a warning is issued and the original object is returned
 #' unchanged.
 #'

--- a/man/add_coordinates.Rd
+++ b/man/add_coordinates.Rd
@@ -18,6 +18,11 @@ appending two new columns: \code{latitude} and \code{longitude}
 This function adds deployment coordinates to \code{observations} based on
 \code{deploymentID}.
 }
+\details{
+When the \code{latitude} and \code{longitude} columns are already present in
+\code{observations}, a warning is issued and the original object is returned
+unchanged.
+}
 \examples{
 x <- example_dataset()
 

--- a/man/add_coordinates.Rd
+++ b/man/add_coordinates.Rd
@@ -19,7 +19,7 @@ This function adds deployment coordinates to \code{observations} based on
 \code{deploymentID}.
 }
 \details{
-When the \code{latitude} and \code{longitude} columns are already present in
+When the \code{latitude} and/or the \code{longitude} columns are already present in
 \code{observations}, a warning is issued and the original object is returned
 unchanged.
 }

--- a/tests/testthat/test-add_coordinates.R
+++ b/tests/testthat/test-add_coordinates.R
@@ -14,3 +14,22 @@ test_that("add_coordinates returns the expected data.frame", {
     c(colnames(original_obs), "latitude", "longitude")
   )
 })
+
+test_that("add_coordinates doesn't add coordinates if already present", {
+  skip_if_offline()
+  x <- example_dataset()
+  # Add coordinates twice and check that the result is identical
+  expect_identical(
+    add_coordinates(x),
+    suppressWarnings(
+      add_coordinates(x) %>%
+        add_coordinates()
+    )
+  )
+  
+  expect_warning(
+    add_coordinates(x) %>% add_coordinates(),
+    regexp = "Coordinates already present in observations. Returning x.",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-add_coordinates.R
+++ b/tests/testthat/test-add_coordinates.R
@@ -29,7 +29,7 @@ test_that("add_coordinates doesn't add coordinates if already present", {
   
   expect_warning(
     add_coordinates(x) %>% add_coordinates(),
-    regexp = "Coordinates already present in observations. Returning x.",
+    regexp = "Coordinates are not added because they already present in observations.",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-add_coordinates.R
+++ b/tests/testthat/test-add_coordinates.R
@@ -3,7 +3,7 @@ test_that("add_coordinates returns the expected data.frame", {
   x <- example_dataset()
   original_obs <- observations(x)
   x <- add_coordinates(x)
-  # New bservations df has same class as the original observations
+  # New observations df has same class as the original observations
   expect_identical(class(observations(x)), class(original_obs))
   # New observations df has the same number of rows as the original observations
   expect_identical(nrow(observations(x)), nrow(original_obs))

--- a/tests/testthat/test-add_coordinates.R
+++ b/tests/testthat/test-add_coordinates.R
@@ -27,6 +27,7 @@ test_that("add_coordinates doesn't add coordinates if already present", {
     )
   )
   
+  # Check the warning message
   expect_warning(
     add_coordinates(x) %>% add_coordinates(),
     regexp = "Coordinates are not added because they already present in observations.",

--- a/tests/testthat/test-add_coordinates.R
+++ b/tests/testthat/test-add_coordinates.R
@@ -33,3 +33,27 @@ test_that("add_coordinates doesn't add coordinates if already present", {
     fixed = TRUE
   )
 })
+
+test_that("add_coordinates doesn't add coordinates if one is already present", {
+  x <- example_dataset()
+  # Add coordinates and remove the `longitude` column from the observations
+  x_with_obs_lat <- x %>%
+    add_coordinates()
+  observations(x_with_obs_lat) <- observations(x_with_obs_lat) %>%
+    dplyr::select(-"longitude")
+  
+  # Add coordinates again and check that the result is identical
+  expect_identical(
+    x_with_obs_lat,
+    suppressWarnings(
+      add_coordinates(x_with_obs_lat)
+    )
+  )
+  
+  # Check the warning message
+  expect_warning(
+    add_coordinates(x_with_obs_lat),
+    regexp = "Coordinates are not added because latitude is already present in observations.",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
I added a little check to make sure that coordinates are only added when either coordinate column is missing. I documented this in `Details` and added a test for it. 

If only one column is missing, a duplicate column is still added and appended with a numeral as default behaviour by dplyr::join functions. 

double coordinates could be added by a double call to `add_coordinates()` but also by calling `summarize_deployments()` and `camtrapR_RecordTable()`, although I'm not sure such a pipeline would make sense, better safe than sorry. 