### PR TITLE
Set upper bound for frictionless as dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     assertthat,
     dplyr (>= 1.1.0),
     EML,
-    frictionless,
+    frictionless (<= 1.2.1),
     glue,
     htmltools,
     leaflet,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Description: Read, explore and visualize Camera Trap Data Packages (Camtrap DP).
 License: MIT + file LICENSE
 BugReports: https://github.com/inbo/camtraptor/issues
 Depends: 
-    R (>= 3.5.0)
+    R (>= 3.6.0)
 Imports:
     activity,
     assertthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: camtraptor
 Title: Read, Explore and Visualize Camera Trap Data Packages
-Version: 0.28.0
+Version: 0.28.1
 Authors@R: c(
     person("Damiano", "Oldoni", , "damiano.oldoni@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3445-7562")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # camtraptor 0.28.1
 
-- set upper bound for frictionless dependency in `DESCRIPTION`: use frictionless 1.2.1 as frictionless 1.3.0 doesn't convert lists to vectors while reading (metadata) fields with multiple values.
+- camtraptor now relies on {frictionless} <= 1.2.1. Later versions of frictionless break downgrading to Camtrap DP 0.1.6 (#420).
 
 # camtraptor 0.28.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# camtraptor 0.28.1
+
+- set upper bound for frictionless dependency in `DESCRIPTION`: use frictionless 1.2.1 as frictionless 1.3.0 doesn't convert lists to vectors while reading (metadata) fields with multiple values.
+
 # camtraptor 0.28.0
 
 - `get_detection_history()` calculates the detection history based on a record table and a camera operation matrix. Some analogies with the `camtrapR::detectionHistory` function (#360).


### PR DESCRIPTION
This pull request sets an upper bound for the `frictionless` package dependency to version 1.2.1. This change is necessary to solve issues while reading data packages. In particular, this should fix  #418. Tested locally, no errors returned.
From 0.28 we go to 0.28.1 as this is just a patch.

About documentation: I added a note in `NEWS.md` explaining the reason for the version constraint on `frictionless`.
@peterdesmet: I think you are the best one to check this PR as maintainer of frictionless. Thanks! 
