### PR TITLE
Link camtrapR-support functions to vignettes

### DIFF
--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("superseded")`
 #' 
-#' This function is superseded because camtrapR now supports reading Camera Trap
+#' This function is superseded because camtrapR supports reading Camera Trap
 #' Data Packages. Use [camtrapR::readCamtrapDP()] and
 #' [camtrapR::cameraOperation()] instead.
 #' 

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -11,7 +11,7 @@
 #' for more details on how to use this function.
 #' 
 #' @details
-#' The deployment data are by default grouped by `locationName` (station ID in
+#' The deployment data are by default grouped by `locationName` (Station ID in
 #' camtrapR jargon) or another column specified by the user via the 
 #' `station_col` argument. If multiple deployments are linked to the same 
 #' location, daily efforts higher than 1 occur.
@@ -31,8 +31,8 @@
 #'   [camtrapR::cameraOperation()].
 #'   Default: `FALSE`.
 #' @inheritParams summarize_deployments
-#' @returns A matrix. Row names always indicate the station ID. Column names are
-#'   dates.
+#' @returns A matrix. Rows are camera stations and columns are occassions 
+#'   (dates). Values indicate whether a camera was operational.
 #' @family deprecated camtrapR-derived functions
 #' @export
 #' @examples

--- a/R/get_cam_op.R
+++ b/R/get_cam_op.R
@@ -7,8 +7,8 @@
 #' Data Packages. Use [camtrapR::readCamtrapDP()] and
 #' [camtrapR::cameraOperation()] instead.
 #' 
-#' Creates the camera operation matrix as returned by
-#' [camtrapR::cameraOperation()].
+#' Creates a camera operation matrix. See `vignette("camera-operation-matrix")`
+#' for more details on how to use this function.
 #' 
 #' @details
 #' The deployment data are by default grouped by `locationName` (station ID in

--- a/R/get_detection_history.R
+++ b/R/get_detection_history.R
@@ -7,18 +7,9 @@
 #' Data Packages. Use [camtrapR::readCamtrapDP()] and
 #' [camtrapR::detectionHistory()] instead.
 #' 
-#' Creates the detection history matrix of a species based on the
-#' record table and the camera operation matrix. The detection history is a 
-#' concept developed within the camtrapR package, see the function documentation 
-#' for [camtrapR::detectionHistory()].
-#'
-#' The detection history matrix is a binary matrix where rows represent camera
-#' stations and columns represent occasions. The matrix is filled with 1s and
-#' 0s, where 1 indicates that the species was detected at a station on a given
-#' occasion and 0 indicates that the species was not detected. The function also
-#' returns the effort matrix, which contains the number of days that each
-#' station was active on each occasion, and the dates matrix, which contains the
-#' dates of the occasions.
+#' Creates species detection matrices. See 
+#' `vignette("detection-history-matrix")` for more details on how to use
+#' this function.
 #' 
 #' @details
 #' If the camera operation matrix (`camOp`) was created for a multi-season study

--- a/R/get_detection_history.R
+++ b/R/get_detection_history.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("superseded")`
 #' 
-#' This function is superseded because camtrapR now supports reading Camera Trap
+#' This function is superseded because camtrapR supports reading Camera Trap
 #' Data Packages. Use [camtrapR::readCamtrapDP()] and
 #' [camtrapR::detectionHistory()] instead.
 #' 

--- a/R/get_detection_history.R
+++ b/R/get_detection_history.R
@@ -21,11 +21,6 @@
 #' dates of the occasions.
 #' 
 #' @details
-#' This function doesn't take as input a Camera Trap Data Package object, but a
-#' camera operation matrix and a record table, which are both calculated based
-#' on a Camera Trap Data Package object. For more information, see the
-#' [get_cam_op()] and [get_record_table()] functions.
-#' 
 #' If the camera operation matrix (`camOp`) was created for a multi-season study
 #' (via argument `session_col` in `get_cam_op()`), the session will be detected
 #' automatically. You can then set `unmarkedMultFrameInput` = `TRUE` to generate
@@ -33,14 +28,8 @@
 #' columns are in season-major, occasion-minor order, e.g. `o1_SESS_A`,
 #' `o2_SESS_A`, `o1_SESS_B`, `o2_SESS_B`, etc.
 #' 
-#' @param recordTable A data frame with the camera trap records. The data frame
-#'   should contain the columns 'Station', 'Date', 'Species' and 'n'. 'Station'
-#'   is the camera station ID, 'Date' is the date of the record, 'Species' is
-#'   the species name, 'n' is the number of observations, and 'n_ind' is the
-#'   number of individuals detected.
-#' @param camOp A matrix with camera operation data. Rows represent camera
-#'   stations and columns represent occasions. The matrix should contain the
-#'   number of days that each station was active on each occasion.
+#' @param recordTable A record table created by `get_record_table()`.
+#' @param camOp A camera operation matrix created by `get_cam_op()`.
 #' @param species Character. The species name.
 #' @param output Character. The type of output. Choose one of: `"binary"`,
 #'   `"n_observations"`, `"n_individuals"`.

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -6,16 +6,10 @@
 #' This function is superseded because camtrapR supports reading Camera Trap
 #' Data Packages. Use [camtrapR::readCamtrapDP()] and [camtrapR::recordTable()]
 #' instead.
-#' 
-#' Creates the record table from a Camera Trap Data Package and so tabulating
-#' species records. Only event-based observations and their corresponding media
-#' are taken into account. The record table is a concept developed within the
-#' camtrapR package, see [this article](
-#' https://jniedballa.github.io/camtrapR/articles/camtrapr3.html). See also the
-#' function documentation for [camtrapR::recordTable()].
-#' 
-#' **Note**: All dates and times are expressed in UTC format.
 #'
+#' Creates a record table. All dates and times are expressed in UTC format. See
+#' `vignette("record-table")` for more details on how to use this function.
+#' 
 #' @param stationCol Character name of the column containing stations.
 #'   Default: `"locationName"`.
 #' @param exclude Character vector of scientific names to be excluded from the

--- a/R/get_record_table.R
+++ b/R/get_record_table.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("superseded")`
 #' 
-#' This function is superseded because camtrapR now supports reading Camera Trap
+#' This function is superseded because camtrapR supports reading Camera Trap
 #' Data Packages. Use [camtrapR::readCamtrapDP()] and [camtrapR::recordTable()]
 #' instead.
 #' 

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,7 +74,7 @@ x %>%
 ## Relation to other R packages
 
 - [camtrapdp](https://cran.r-project.org/package=camtrapdp) is a core R package to read and manipulate Camtrap DPs. camtraptor depends on camtrapdp and re-exports a number of functions so that users don't need to load both packages.
-- [camtrapR](https://cran.r-project.org/package=camtrapR) is an analysis R package for camera trap data. camtraptor initially offered a number of functions to transform Camtrap DPs to outputs compatible with camtrapR. These have been superseded, because camtrapR now supports reading Camtrap DPs.
+- [camtrapR](https://cran.r-project.org/package=camtrapR) is an analysis R package for camera trap data. camtraptor initially offered a number of functions to transform Camtrap DPs to outputs compatible with camtrapR. These have been superseded, because camtrapR supports reading Camtrap DPs.
 - [camtrapDensity](https://github.com/MarcusRowcliffe/camtrapDensity) is a development R package to run single species random encounter models to estimate animal density. camtraptor is a dependency.
 
 ## Meta

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ x %>%
 - [camtrapR](https://cran.r-project.org/package=camtrapR) is an analysis
   R package for camera trap data. camtraptor initially offered a number
   of functions to transform Camtrap DPs to outputs compatible with
-  camtrapR. These have been superseded, because camtrapR now supports
+  camtrapR. These have been superseded, because camtrapR supports
   reading Camtrap DPs.
 - [camtrapDensity](https://github.com/MarcusRowcliffe/camtrapDensity) is
   a development R package to run single species random encounter models

--- a/man/get_cam_op.Rd
+++ b/man/get_cam_op.Rd
@@ -32,8 +32,8 @@ names will start with prefix \code{"Station"} as returned by
 Default: \code{FALSE}.}
 }
 \value{
-A matrix. Row names always indicate the station ID. Column names are
-dates.
+A matrix. Rows are camera stations and columns are occassions
+(dates). Values indicate whether a camera was operational.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
@@ -46,7 +46,7 @@ Creates a camera operation matrix. See \code{vignette("camera-operation-matrix")
 for more details on how to use this function.
 }
 \details{
-The deployment data are by default grouped by \code{locationName} (station ID in
+The deployment data are by default grouped by \code{locationName} (Station ID in
 camtrapR jargon) or another column specified by the user via the
 \code{station_col} argument. If multiple deployments are linked to the same
 location, daily efforts higher than 1 occur.

--- a/man/get_cam_op.Rd
+++ b/man/get_cam_op.Rd
@@ -38,7 +38,7 @@ dates.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
-This function is superseded because camtrapR now supports reading Camera Trap
+This function is superseded because camtrapR supports reading Camera Trap
 Data Packages. Use \code{\link[camtrapR:readCamtrapDP]{camtrapR::readCamtrapDP()}} and
 \code{\link[camtrapR:cameraOperation]{camtrapR::cameraOperation()}} instead.
 

--- a/man/get_cam_op.Rd
+++ b/man/get_cam_op.Rd
@@ -42,8 +42,8 @@ This function is superseded because camtrapR supports reading Camera Trap
 Data Packages. Use \code{\link[camtrapR:readCamtrapDP]{camtrapR::readCamtrapDP()}} and
 \code{\link[camtrapR:cameraOperation]{camtrapR::cameraOperation()}} instead.
 
-Creates the camera operation matrix as returned by
-\code{\link[camtrapR:cameraOperation]{camtrapR::cameraOperation()}}.
+Creates a camera operation matrix. See \code{vignette("camera-operation-matrix")}
+for more details on how to use this function.
 }
 \details{
 The deployment data are by default grouped by \code{locationName} (station ID in

--- a/man/get_detection_history.Rd
+++ b/man/get_detection_history.Rd
@@ -68,18 +68,9 @@ This function is superseded because camtrapR supports reading Camera Trap
 Data Packages. Use \code{\link[camtrapR:readCamtrapDP]{camtrapR::readCamtrapDP()}} and
 \code{\link[camtrapR:detectionHistory]{camtrapR::detectionHistory()}} instead.
 
-Creates the detection history matrix of a species based on the
-record table and the camera operation matrix. The detection history is a
-concept developed within the camtrapR package, see the function documentation
-for \code{\link[camtrapR:detectionHistory]{camtrapR::detectionHistory()}}.
-
-The detection history matrix is a binary matrix where rows represent camera
-stations and columns represent occasions. The matrix is filled with 1s and
-0s, where 1 indicates that the species was detected at a station on a given
-occasion and 0 indicates that the species was not detected. The function also
-returns the effort matrix, which contains the number of days that each
-station was active on each occasion, and the dates matrix, which contains the
-dates of the occasions.
+Creates species detection matrices. See
+\code{vignette("detection-history-matrix")} for more details on how to use
+this function.
 }
 \details{
 If the camera operation matrix (\code{camOp}) was created for a multi-season study

--- a/man/get_detection_history.Rd
+++ b/man/get_detection_history.Rd
@@ -18,15 +18,9 @@ get_detection_history(
 )
 }
 \arguments{
-\item{recordTable}{A data frame with the camera trap records. The data frame
-should contain the columns 'Station', 'Date', 'Species' and 'n'. 'Station'
-is the camera station ID, 'Date' is the date of the record, 'Species' is
-the species name, 'n' is the number of observations, and 'n_ind' is the
-number of individuals detected.}
+\item{recordTable}{A record table created by \code{get_record_table()}.}
 
-\item{camOp}{A matrix with camera operation data. Rows represent camera
-stations and columns represent occasions. The matrix should contain the
-number of days that each station was active on each occasion.}
+\item{camOp}{A camera operation matrix created by \code{get_cam_op()}.}
 
 \item{species}{Character. The species name.}
 
@@ -88,11 +82,6 @@ station was active on each occasion, and the dates matrix, which contains the
 dates of the occasions.
 }
 \details{
-This function doesn't take as input a Camera Trap Data Package object, but a
-camera operation matrix and a record table, which are both calculated based
-on a Camera Trap Data Package object. For more information, see the
-\code{\link[=get_cam_op]{get_cam_op()}} and \code{\link[=get_record_table]{get_record_table()}} functions.
-
 If the camera operation matrix (\code{camOp}) was created for a multi-season study
 (via argument \code{session_col} in \code{get_cam_op()}), the session will be detected
 automatically. You can then set \code{unmarkedMultFrameInput} = \code{TRUE} to generate

--- a/man/get_detection_history.Rd
+++ b/man/get_detection_history.Rd
@@ -70,7 +70,7 @@ A list with three elements:
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
-This function is superseded because camtrapR now supports reading Camera Trap
+This function is superseded because camtrapR supports reading Camera Trap
 Data Packages. Use \code{\link[camtrapR:readCamtrapDP]{camtrapR::readCamtrapDP()}} and
 \code{\link[camtrapR:detectionHistory]{camtrapR::detectionHistory()}} instead.
 

--- a/man/get_record_table.Rd
+++ b/man/get_record_table.Rd
@@ -82,7 +82,7 @@ Nouvellet et al. (2012) \doi{10.1111/j.1469-7998.2011.00864.x}.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
-This function is superseded because camtrapR now supports reading Camera Trap
+This function is superseded because camtrapR supports reading Camera Trap
 Data Packages. Use \code{\link[camtrapR:readCamtrapDP]{camtrapR::readCamtrapDP()}} and \code{\link[camtrapR:recordTable]{camtrapR::recordTable()}}
 instead.
 

--- a/man/get_record_table.Rd
+++ b/man/get_record_table.Rd
@@ -86,13 +86,8 @@ This function is superseded because camtrapR supports reading Camera Trap
 Data Packages. Use \code{\link[camtrapR:readCamtrapDP]{camtrapR::readCamtrapDP()}} and \code{\link[camtrapR:recordTable]{camtrapR::recordTable()}}
 instead.
 
-Creates the record table from a Camera Trap Data Package and so tabulating
-species records. Only event-based observations and their corresponding media
-are taken into account. The record table is a concept developed within the
-camtrapR package, see \href{https://jniedballa.github.io/camtrapR/articles/camtrapr3.html}{this article}. See also the
-function documentation for \code{\link[camtrapR:recordTable]{camtrapR::recordTable()}}.
-
-\strong{Note}: All dates and times are expressed in UTC format.
+Creates a record table. All dates and times are expressed in UTC format. See
+\code{vignette("record-table")} for more details on how to use this function.
 }
 \examples{
 library(lubridate)

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -38,7 +38,7 @@ reference:
   - has_concept("deprecated visualization functions")
 - title: Create outputs for camtrapR
   desc: >
-    These functions are superseded because camtrapR now supports reading Camera 
+    These functions are superseded because camtrapR supports reading Camera 
     Trap Data Packages.
   contents:
   - has_concept("deprecated camtrapR-derived functions")

--- a/vignettes/camera-operation-matrix.Rmd
+++ b/vignettes/camera-operation-matrix.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.callout-note}
-This functionality has been superseded because camtrapR supports reading Camera Trap Data Packages, see the function `camtrapR::readCamtrapDP()`.
+This functionality is superseded because camtrapR supports reading Camera Trap Data Packages. Use `camtrapR::readCamtrapDP()` and `camtrapR::cameraOperation()` instead.
 :::
 
 This vignette shows how to get a **camera operation matrix** from a Camera Trap Data Package dataset, equivalent to the matrix returned by camtrapR's function `camtrapR::cameraOperation()`.

--- a/vignettes/detection-history-matrix.Rmd
+++ b/vignettes/detection-history-matrix.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.callout-note}
-This functionality has been superseded because camtrapR supports reading Camera Trap Data Packages, see the function `camtrapR::readCamtrapDP()`.
+This functionality is superseded because camtrapR supports reading Camera Trap Data Packages. Use `camtrapR::readCamtrapDP()` and `camtrapR::detectionHistory()` instead.
 :::
 
 This vignette shows how to get a **detection history matrix** from a Camera Trap Data Package dataset, equivalent to the matrix returned by camtrapR's function `camtrapR::detectionHistory()`.

--- a/vignettes/record-table.Rmd
+++ b/vignettes/record-table.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 ::: {.callout-note}
-This functionality has been superseded because camtrapR supports reading Camera Trap Data Packages, see the function `camtrapR::readCamtrapDP()`.
+This functionality is superseded because camtrapR supports reading Camera Trap Data Packages. Use `camtrapR::readCamtrapDP()` and `camtrapR::recordTable()` instead.
 :::
 
 This vignette shows how to get a **species record table** from a Camera Trap Data Package dataset, equivalent to the record table returned by camtrapR's function [recordTable](https://jniedballa.github.io/camtrapR/reference/recordTable.html).


### PR DESCRIPTION
I think all 3 camtrapR-support functions should link to their respective vignette, high up in their description.

- I've also simplified the description of the first 2 arguments of `get_detection_history()`, so it's clear those inputs are generated by the other two functions
- And standardized the note on why these are superseded.

Please review and merge this before #405.